### PR TITLE
Added SKALE Network Testnet Endpoint

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -37,6 +37,10 @@ module.exports = {
       provider: () => new PrivateKeyProvider(PRIV_KEY, 'https://rpc.testnet.moonbeam.network', 1287),
       network_id: '1287',
     },
+    skale: {
+      provider: () => new HDWalletProvider(MNEMONIC, 'https://humanprotocol-integration.skale.network', 0, 10),
+      network_id: '344435',
+    },
   },
   compilers: {
     solc: {


### PR DESCRIPTION
This PR adds the necessary changes so that the Truffle script works for deploying the contracts into the SKALE Network's TestNet SKALE Chain.

The SKALE Network's EVM is completely compatible with all Ethereum based tooling. To deploy solidity based smart contracts into the SKALE Network you will just need to switch the endpoint to point to SKALE. Since the SKALE Network is a multi-chain platform, each application receives its own dedicated SKALE Chain within the network that does not share TPS or storage with any other application running within SKALE. This ensures that dApps will never compete for resources on their SKALE Chain within the SKALE Network.

Transactions run on SKALE are gas-less; however, in order for a user to process transactions on your SKALE Chain, their wallet will need to contain a very small amount of SKALE Chain test ETH. This is to protect your SKALE Chain against DDoS attacks. Think of this step as giving users “permission” to use your SKALE Chain.

On testnet, you can either use the faucet to fund accounts with SKALE specific ETH which is a fast way to start testing, or you can use the SKALE Chains owner account to distribute SKALE specific ETH to the wallets that will be running transactions on your SKALE Chain. The faucet can be found below, and to get the SKALE Chain owner account credentials please reach out to the SKALE team directly.

Faucet: https://faucet.skale.network

You can find more information about the SKALE Network below:

SKALE Network: https://skale.network
Dev Documentation: https://skale.network/docs
Discord: http://http://skale.chat

2 Minute Explainer Video: https://www.youtube.com/watch?v=Anb0ZSruWlw