### PR TITLE
Make Escrow.sol pure ERC20 compatible contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.10",
+  "version": "0.10.0",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.9.10",
+    version="0.10.0",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",


### PR DESCRIPTION
Some networks(like Polygon Mainnet) have a standard ERC20 implementation of the HMT. This makes it impossible to use HMT native bulk* methods in Escrow contracts. So that's why Escrow's bulkPayOut was modified and now includes the bulk transfer within the contract, instead of executing it on behalf HMT contract.

Existing setups which use previous Escrow implementations should not be broken, since Escrow ABI not changed at all(as well as hmt-escrow interface)
