### PR TITLE
#297 Change warning logs to debug logs for retry tx

### DIFF
--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -438,7 +438,7 @@ class Job:
             handle_transaction_with_retry(txn_func, self.retry, *func_args, **txn_info)
             hmt_transferred = True
         except Exception as e:
-            LOG.info(
+            LOG.debug(
                 f"{txn_event} failed with main credentials: {self.gas_payer}, {self.gas_payer_priv} due to {e}. Using secondary ones..."
             )
 
@@ -449,7 +449,7 @@ class Job:
 
         # give up
         if not hmt_transferred:
-            LOG.exception(
+            LOG.warning(
                 f"{txn_event} failed with all credentials, not continuing to setup."
             )
             return False
@@ -469,7 +469,7 @@ class Job:
             handle_transaction_with_retry(txn_func, self.retry, *func_args, **txn_info)
             contract_is_setup = True
         except Exception as e:
-            LOG.info(
+            LOG.debug(
                 f"{txn_event} failed with main credentials: {self.gas_payer}, {self.gas_payer_priv} due to {e}. Using secondary ones..."
             )
 
@@ -479,7 +479,7 @@ class Job:
             )
 
         if not contract_is_setup:
-            LOG.exception(f"{txn_event} failed with all credentials.")
+            LOG.warning(f"{txn_event} failed with all credentials.")
 
         return (
             str(self.status()) == str(Status.Pending) and self.balance() == hmt_amount
@@ -628,7 +628,7 @@ class Job:
             handle_transaction_with_retry(txn_func, self.retry, *func_args, **txn_info)
             return self._bulk_paid() == True
         except Exception as e:
-            LOG.info(
+            LOG.debug(
                 f"{txn_event} failed with main credentials: {self.gas_payer}, {self.gas_payer_priv} due to {e}. Using secondary ones..."
             )
 
@@ -637,7 +637,7 @@ class Job:
         )
 
         if not bulk_paid:
-            LOG.exception(f"{txn_event} failed with all credentials.")
+            LOG.warning(f"{txn_event} failed with all credentials.")
 
         return bulk_paid == True
 
@@ -1496,7 +1496,7 @@ class Job:
                 txn_succeeded = True
                 break
             except Exception as e:
-                LOG.info(
+                LOG.debug(
                     f"{txn_event} failed with {gas_payer} and {gas_payer_priv} due to {e}."
                 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.9.7",
+    version="0.9.8",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",


### PR DESCRIPTION
closes #297

Use DEBUG level for retry transaction logs



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200560623420491/1201985706008519) by [Unito](https://www.unito.io)
