### PR TITLE
replace warning with debug log level for failed transaction

### DIFF
--- a/hmt_escrow/eth_bridge.py
+++ b/hmt_escrow/eth_bridge.py
@@ -163,10 +163,10 @@ def handle_transaction_with_retry(
             return handle_transaction(txn_func, *args, **kwargs)
         except Exception as e:
             if i == retry.retries:
-                LOG.warning(f"giving up on transaction after {i} retries")
+                LOG.debug(f"giving up on transaction after {i} retries")
                 raise e
             else:
-                LOG.warning(
+                LOG.debug(
                     f"(x{i+1}) handle_transaction: {e}. Retrying after {wait_time} sec..."
                 )
                 sleep(wait_time)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.9.8",
+    version="0.9.9",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",


### PR DESCRIPTION
Missed one place from previous PR where we log a warning instead of a debug



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200560623420491/1202007134652838) by [Unito](https://www.unito.io)
