### PR TITLE
use secondary gas payers if main one is low on hmt

### DIFF
--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -1845,6 +1845,7 @@ class JobTestCase(unittest.TestCase):
             1000000,
         )
 
+
 if __name__ == "__main__":
     from test_manifest import manifest
 

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -25,7 +25,7 @@ from hmt_escrow.eth_bridge import (
     get_w3,
     handle_transaction_with_retry,
     Retry,
-    HMTOKEN_ADDR
+    HMTOKEN_ADDR,
 )
 from hmt_escrow import utils
 from hmt_escrow.storage import download, upload
@@ -435,15 +435,13 @@ class Job:
             txn_func = hmtoken_contract.functions.transfer
             func_args = [self.job_contract.address, hmt_amount]
 
-        balance = utils.get_hmt_balance(
-            self.gas_payer,
-            HMTOKEN_ADDR,
-            get_w3()
-        )
+        balance = utils.get_hmt_balance(self.gas_payer, HMTOKEN_ADDR, get_w3())
 
-        if balance and balance > hmt_amount:
+        if not balance or balance > hmt_amount:
             try:
-                handle_transaction_with_retry(txn_func, self.retry, *func_args, **txn_info)
+                handle_transaction_with_retry(
+                    txn_func, self.retry, *func_args, **txn_info
+                )
                 hmt_transferred = True
             except Exception as e:
                 LOG.debug(

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -437,7 +437,8 @@ class Job:
 
         balance = utils.get_hmt_balance(self.gas_payer, HMTOKEN_ADDR, get_w3())
 
-        if not balance or balance > hmt_amount:
+        # make sure there is enough HMT to fund the escrow
+        if balance > hmt_amount:
             try:
                 handle_transaction_with_retry(
                     txn_func, self.retry, *func_args, **txn_info
@@ -1833,6 +1834,16 @@ class JobTestCase(unittest.TestCase):
             )
             self.assertEqual(sleep_mock.call_args_list, [])
 
+    def test_get_hmt_balance(self):
+        """ Test wallet HMT balance is OK """
+        self.assertGreater(
+            utils.get_hmt_balance(
+                "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
+                "0x56B532F1D090E4edb1c92F30d3087771AE6B6992",
+                get_w3()
+            )
+            , 1000000
+        )
 
 if __name__ == "__main__":
     from test_manifest import manifest

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -1840,9 +1840,9 @@ class JobTestCase(unittest.TestCase):
             utils.get_hmt_balance(
                 "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
                 "0x56B532F1D090E4edb1c92F30d3087771AE6B6992",
-                get_w3()
+                get_w3(),
             )
-            , 1000000
+            , 1000000,
         )
 
 if __name__ == "__main__":

--- a/hmt_escrow/job.py
+++ b/hmt_escrow/job.py
@@ -1841,8 +1841,8 @@ class JobTestCase(unittest.TestCase):
                 "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
                 "0x56B532F1D090E4edb1c92F30d3087771AE6B6992",
                 get_w3(),
-            )
-            , 1000000,
+            ),
+            1000000,
         )
 
 if __name__ == "__main__":

--- a/hmt_escrow/utils.py
+++ b/hmt_escrow/utils.py
@@ -59,17 +59,14 @@ def get_hmt_balance(wallet_addr, token_addr, w3):
     Return:
         Decimal with HMT balance
     """
-    try:
-        abi = [
-            {
-                "constant": True,
-                "inputs": [{"name": "_owner", "type": "address"}],
-                "name": "balanceOf",
-                "outputs": [{"name": "balance", "type": "uint256"}],
-                "type": "function",
-            }
-        ]
-        contract = w3.eth.contract(abi=abi, address=token_addr)
-        return contract.functions.balanceOf(wallet_addr).call()
-    except Exception as e:
-        logger.warning(f"Can't get HMT Balance: {e}")
+    abi = [
+        {
+            "constant": True,
+            "inputs": [{"name": "_owner", "type": "address"}],
+            "name": "balanceOf",
+            "outputs": [{"name": "balance", "type": "uint256"}],
+            "type": "function",
+        }
+    ]
+    contract = w3.eth.contract(abi=abi, address=token_addr)
+    return contract.functions.balanceOf(wallet_addr).call()

--- a/hmt_escrow/utils.py
+++ b/hmt_escrow/utils.py
@@ -48,11 +48,7 @@ def with_retry(fn, retries=3, delay=5, backoff=2):
     return False
 
 
-def get_hmt_balance(
-    wallet_addr,
-    token_addr,
-    w3
-):
+def get_hmt_balance(wallet_addr, token_addr, w3):
     """ Get hmt balance
 
     Args:
@@ -64,16 +60,16 @@ def get_hmt_balance(
         Decimal with HMT balance
     """
     try:
-        abi = [{
-            "constant": True,
-            "inputs": [{ "name": "_owner", "type": "address" }],
-            "name": "balanceOf",
-            "outputs": [{ "name": "balance", "type": "uint256" }],
-            "type": "function",
-        }]
+        abi = [
+            {
+                "constant": True,
+                "inputs": [{"name": "_owner", "type": "address"}],
+                "name": "balanceOf",
+                "outputs": [{"name": "balance", "type": "uint256"}],
+                "type": "function",
+            }
+        ]
         contract = w3.eth.contract(abi=abi, address=token_addr)
         return contract.functions.balanceOf(wallet_addr).call()
     except Exception as e:
-        logger.warning(
-            f"Can't get HMT Balance: {e}"
-        )
+        logger.warning(f"Can't get HMT Balance: {e}")

--- a/hmt_escrow/utils.py
+++ b/hmt_escrow/utils.py
@@ -46,3 +46,34 @@ def with_retry(fn, retries=3, delay=5, backoff=2):
         wait_time *= backoff
 
     return False
+
+
+def get_hmt_balance(
+    wallet_addr,
+    token_addr,
+    w3
+):
+    """ Get hmt balance
+
+    Args:
+        wallet_addr: wallet address
+        token_addr: ERC-20 contract
+        w3: Web3 instance
+
+    Return:
+        Decimal with HMT balance
+    """
+    try:
+        abi = [{
+            "constant": True,
+            "inputs": [{ "name": "_owner", "type": "address" }],
+            "name": "balanceOf",
+            "outputs": [{ "name": "balance", "type": "uint256" }],
+            "type": "function",
+        }]
+        contract = w3.eth.contract(abi=abi, address=token_addr)
+        return contract.functions.balanceOf(wallet_addr).call()
+    except Exception as e:
+        logger.warning(
+            f"Can't get HMT Balance: {e}"
+        )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.9.9",
+    version="0.9.10",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",


### PR DESCRIPTION
closes #301 

When the main gas payer is low in HMT, the transaction is accepted and then reverted, causing jobs not to be deployed.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1200560623420491/1202045638243182) by [Unito](https://www.unito.io)
