### PR TITLE
Polygon Mainnet: Human Token smart contracts

### DIFF
--- a/polygon_contracts/AccessControlMixin.sol
+++ b/polygon_contracts/AccessControlMixin.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.6.6;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract AccessControlMixin is AccessControl {
+    string private _revertMsg;
+    function _setupContractId(string memory contractId) internal {
+        _revertMsg = string(abi.encodePacked(contractId, ": INSUFFICIENT_PERMISSIONS"));
+    }
+
+    modifier only(bytes32 role) {
+        require(
+            hasRole(role, _msgSender()),
+            _revertMsg
+        );
+        _;
+    }
+}

--- a/polygon_contracts/ChainConstants.sol
+++ b/polygon_contracts/ChainConstants.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.6.6;
+
+contract ChainConstants {
+    string constant public ERC712_VERSION = "1";
+
+    uint256 constant public ROOT_CHAIN_ID = 1;
+    bytes constant public ROOT_CHAIN_ID_BYTES = hex"01";
+
+    uint256 constant public CHILD_CHAIN_ID = 137;
+    bytes constant public CHILD_CHAIN_ID_BYTES = hex"89";
+}

--- a/polygon_contracts/ContextMixin.sol
+++ b/polygon_contracts/ContextMixin.sol
@@ -1,0 +1,24 @@
+pragma solidity 0.6.6;
+
+abstract contract ContextMixin {
+    function msgSender()
+        internal
+        view
+        returns (address payable sender)
+    {
+        if (msg.sender == address(this)) {
+            bytes memory array = msg.data;
+            uint256 index = msg.data.length;
+            assembly {
+                // Load the 32 bytes word from memory with the address on the lower 20 bytes, and mask those.
+                sender := and(
+                    mload(add(array, index)),
+                    0xffffffffffffffffffffffffffffffffffffffff
+                )
+            }
+        } else {
+            sender = msg.sender;
+        }
+        return sender;
+    }
+}

--- a/polygon_contracts/EIP712Base.sol
+++ b/polygon_contracts/EIP712Base.sol
@@ -1,0 +1,74 @@
+pragma solidity 0.6.6;
+
+import "./Initializable.sol";
+
+contract EIP712Base is Initializable {
+    struct EIP712Domain {
+        string name;
+        string version;
+        address verifyingContract;
+        bytes32 salt;
+    }
+
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(
+        bytes(
+            "EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"
+        )
+    );
+    bytes32 internal domainSeperator;
+
+    // supposed to be called once while initializing.
+    // one of the contractsa that inherits this contract follows proxy pattern
+    // so it is not possible to do this in a constructor
+    function _initializeEIP712(
+        string memory name,
+        string memory version
+    )
+        internal
+        initializer
+    {
+        _setDomainSeperator(name, version);
+    }
+
+    function _setDomainSeperator(string memory name, string memory version) internal {
+        domainSeperator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes(name)),
+                keccak256(bytes(version)),
+                address(this),
+                bytes32(getChainId())
+            )
+        );
+    }
+
+    function getDomainSeperator() public view returns (bytes32) {
+        return domainSeperator;
+    }
+
+    function getChainId() public pure returns (uint256) {
+        uint256 id;
+        assembly {
+            id := chainid()
+        }
+        return id;
+    }
+
+    /**
+     * Accept message hash and returns hash message in EIP712 compatible form
+     * So that it can be used to recover signer from signature signed using EIP712 formatted data
+     * https://eips.ethereum.org/EIPS/eip-712
+     * "\\x19" makes the encoding deterministic
+     * "\\x01" is the version byte to make it compatible to EIP-191
+     */
+    function toTypedMessageHash(bytes32 messageHash)
+        internal
+        view
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encodePacked("\x19\x01", getDomainSeperator(), messageHash)
+            );
+    }
+}

--- a/polygon_contracts/ERC20.sol
+++ b/polygon_contracts/ERC20.sol
@@ -1,0 +1,326 @@
+pragma solidity ^0.6.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/GSN/Context.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+
+
+/**
+ * Modified openzeppelin implemtation to add setters for name, symbol and decimals.
+ * This was needed because the variables cannot be set in constructor as the contract is upgradeable.
+ */
+
+/**
+ * @dev openzeppelin Implementation of the {IERC20} interface.
+ *
+ * Modified to add setters for name, symbol and decimals. This was needed
+ * because
+ *
+ * This implementation is agnostic to the way tokens are created. This means
+ * that a supply mechanism has to be added in a derived contract using {_mint}.
+ * For a generic mechanism see {ERC20PresetMinterPauser}.
+ *
+ * TIP: For a detailed writeup see our guide
+ * https://forum.zeppelin.solutions/t/how-to-implement-erc20-supply-mechanisms/226[How
+ * to implement supply mechanisms].
+ *
+ * We have followed general OpenZeppelin guidelines: functions revert instead
+ * of returning `false` on failure. This behavior is nonetheless conventional
+ * and does not conflict with the expectations of ERC20 applications.
+ *
+ * Additionally, an {Approval} event is emitted on calls to {transferFrom}.
+ * This allows applications to reconstruct the allowance for all accounts just
+ * by listening to said events. Other implementations of the EIP may not emit
+ * these events, as it isn't required by the specification.
+ *
+ * Finally, the non-standard {decreaseAllowance} and {increaseAllowance}
+ * functions have been added to mitigate the well-known issues around setting
+ * allowances. See {IERC20-approve}.
+ */
+contract ERC20 is Context, IERC20 {
+    using SafeMath for uint256;
+    using Address for address;
+
+    mapping (address => uint256) private _balances;
+
+    mapping (address => mapping (address => uint256)) private _allowances;
+
+    uint256 private _totalSupply;
+
+    string private _name;
+    string private _symbol;
+    uint8 private _decimals;
+
+    /**
+     * @dev Sets the values for {name} and {symbol}, initializes {decimals} with
+     * a default value of 18.
+     *
+     * To select a different value for {decimals}, use {_setupDecimals}.
+     *
+     * All three of these values are immutable: they can only be set once during
+     * construction.
+     */
+    constructor (string memory name, string memory symbol) public {
+        _name = name;
+        _symbol = symbol;
+        _decimals = 18;
+    }
+
+    /**
+     * @dev Returns the name of the token.
+     */
+    function name() public view returns (string memory) {
+        return _name;
+    }
+
+    function setName(string memory newName) internal {
+      _name = newName;
+    }
+
+    /**
+     * @dev Returns the symbol of the token, usually a shorter version of the
+     * name.
+     */
+    function symbol() public view returns (string memory) {
+        return _symbol;
+    }
+
+    function setSymbol(string memory newSymbol) internal {
+      _symbol = newSymbol;
+    }
+
+    /**
+     * @dev Returns the number of decimals used to get its user representation.
+     * For example, if `decimals` equals `2`, a balance of `505` tokens should
+     * be displayed to a user as `5,05` (`505 / 10 ** 2`).
+     *
+     * Tokens usually opt for a value of 18, imitating the relationship between
+     * Ether and Wei. This is the value {ERC20} uses, unless {_setupDecimals} is
+     * called.
+     *
+     * NOTE: This information is only used for _display_ purposes: it in
+     * no way affects any of the arithmetic of the contract, including
+     * {IERC20-balanceOf} and {IERC20-transfer}.
+     */
+    function decimals() public view returns (uint8) {
+        return _decimals;
+    }
+
+    function setDecimals(uint8 newDecimals) internal {
+      _decimals = newDecimals;
+    }
+
+    /**
+     * @dev See {IERC20-totalSupply}.
+     */
+    function totalSupply() public view override returns (uint256) {
+        return _totalSupply;
+    }
+
+    /**
+     * @dev See {IERC20-balanceOf}.
+     */
+    function balanceOf(address account) public view override returns (uint256) {
+        return _balances[account];
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Requirements:
+     *
+     * - `recipient` cannot be the zero address.
+     * - the caller must have a balance of at least `amount`.
+     */
+    function transfer(address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(_msgSender(), recipient, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-allowance}.
+     */
+    function allowance(address owner, address spender) public view virtual override returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    /**
+     * @dev See {IERC20-approve}.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function approve(address spender, uint256 amount) public virtual override returns (bool) {
+        _approve(_msgSender(), spender, amount);
+        return true;
+    }
+
+    /**
+     * @dev See {IERC20-transferFrom}.
+     *
+     * Emits an {Approval} event indicating the updated allowance. This is not
+     * required by the EIP. See the note at the beginning of {ERC20};
+     *
+     * Requirements:
+     * - `sender` and `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     * - the caller must have allowance for ``sender``'s tokens of at least
+     * `amount`.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) public virtual override returns (bool) {
+        _transfer(sender, recipient, amount);
+        _approve(sender, _msgSender(), _allowances[sender][_msgSender()].sub(amount, "ERC20: transfer amount exceeds allowance"));
+        return true;
+    }
+
+    /**
+     * @dev Atomically increases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     */
+    function increaseAllowance(address spender, uint256 addedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].add(addedValue));
+        return true;
+    }
+
+    /**
+     * @dev Atomically decreases the allowance granted to `spender` by the caller.
+     *
+     * This is an alternative to {approve} that can be used as a mitigation for
+     * problems described in {IERC20-approve}.
+     *
+     * Emits an {Approval} event indicating the updated allowance.
+     *
+     * Requirements:
+     *
+     * - `spender` cannot be the zero address.
+     * - `spender` must have allowance for the caller of at least
+     * `subtractedValue`.
+     */
+    function decreaseAllowance(address spender, uint256 subtractedValue) public virtual returns (bool) {
+        _approve(_msgSender(), spender, _allowances[_msgSender()][spender].sub(subtractedValue, "ERC20: decreased allowance below zero"));
+        return true;
+    }
+
+    /**
+     * @dev Moves tokens `amount` from `sender` to `recipient`.
+     *
+     * This is internal function is equivalent to {transfer}, and can be used to
+     * e.g. implement automatic token fees, slashing mechanisms, etc.
+     *
+     * Emits a {Transfer} event.
+     *
+     * Requirements:
+     *
+     * - `sender` cannot be the zero address.
+     * - `recipient` cannot be the zero address.
+     * - `sender` must have a balance of at least `amount`.
+     */
+    function _transfer(address sender, address recipient, uint256 amount) internal virtual {
+        require(sender != address(0), "ERC20: transfer from the zero address");
+        require(recipient != address(0), "ERC20: transfer to the zero address");
+
+        _beforeTokenTransfer(sender, recipient, amount);
+
+        _balances[sender] = _balances[sender].sub(amount, "ERC20: transfer amount exceeds balance");
+        _balances[recipient] = _balances[recipient].add(amount);
+        emit Transfer(sender, recipient, amount);
+    }
+
+    /** @dev Creates `amount` tokens and assigns them to `account`, increasing
+     * the total supply.
+     *
+     * Emits a {Transfer} event with `from` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `to` cannot be the zero address.
+     */
+    function _mint(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: mint to the zero address");
+
+        _beforeTokenTransfer(address(0), account, amount);
+
+        _totalSupply = _totalSupply.add(amount);
+        _balances[account] = _balances[account].add(amount);
+        emit Transfer(address(0), account, amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, reducing the
+     * total supply.
+     *
+     * Emits a {Transfer} event with `to` set to the zero address.
+     *
+     * Requirements
+     *
+     * - `account` cannot be the zero address.
+     * - `account` must have at least `amount` tokens.
+     */
+    function _burn(address account, uint256 amount) internal virtual {
+        require(account != address(0), "ERC20: burn from the zero address");
+
+        _beforeTokenTransfer(account, address(0), amount);
+
+        _balances[account] = _balances[account].sub(amount, "ERC20: burn amount exceeds balance");
+        _totalSupply = _totalSupply.sub(amount);
+        emit Transfer(account, address(0), amount);
+    }
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the `owner`s tokens.
+     *
+     * This is internal function is equivalent to `approve`, and can be used to
+     * e.g. set automatic allowances for certain subsystems, etc.
+     *
+     * Emits an {Approval} event.
+     *
+     * Requirements:
+     *
+     * - `owner` cannot be the zero address.
+     * - `spender` cannot be the zero address.
+     */
+    function _approve(address owner, address spender, uint256 amount) internal virtual {
+        require(owner != address(0), "ERC20: approve from the zero address");
+        require(spender != address(0), "ERC20: approve to the zero address");
+
+        _allowances[owner][spender] = amount;
+        emit Approval(owner, spender, amount);
+    }
+
+    /**
+     * @dev Sets {decimals} to a value other than the default one of 18.
+     *
+     * WARNING: This function should only be called from the constructor. Most
+     * applications that interact with token contracts will not expect
+     * {decimals} to ever change, and may work incorrectly if it does.
+     */
+    function _setupDecimals(uint8 decimals_) internal {
+        _decimals = decimals_;
+    }
+
+    /**
+     * @dev Hook that is called before any transfer of tokens. This includes
+     * minting and burning.
+     *
+     * Calling conditions:
+     *
+     * - when `from` and `to` are both non-zero, `amount` of ``from``'s tokens
+     * will be to transferred to `to`.
+     * - when `from` is zero, `amount` tokens will be minted for `to`.
+     * - when `to` is zero, `amount` of ``from``'s tokens will be burned.
+     * - `from` and `to` are never both zero.
+     *
+     * To learn more about hooks, head to xref:ROOT:extending-contracts.adoc#using-hooks[Using Hooks].
+     */
+    function _beforeTokenTransfer(address from, address to, uint256 amount) internal virtual { }
+}

--- a/polygon_contracts/IChildToken.sol
+++ b/polygon_contracts/IChildToken.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.6.6;
+
+interface IChildToken {
+    function deposit(address user, bytes calldata depositData) external;
+}

--- a/polygon_contracts/Initializable.sol
+++ b/polygon_contracts/Initializable.sol
@@ -1,0 +1,11 @@
+pragma solidity 0.6.6;
+
+contract Initializable {
+    bool inited = false;
+
+    modifier initializer() {
+        require(!inited, "already inited");
+        _;
+        inited = true;
+    }
+}

--- a/polygon_contracts/NativeMetaTransaction.sol
+++ b/polygon_contracts/NativeMetaTransaction.sol
@@ -1,0 +1,104 @@
+pragma solidity 0.6.6;
+
+import "./EIP712Base.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+contract NativeMetaTransaction is EIP712Base {
+    using SafeMath for uint256;
+    bytes32 private constant META_TRANSACTION_TYPEHASH = keccak256(
+        bytes(
+            "MetaTransaction(uint256 nonce,address from,bytes functionSignature)"
+        )
+    );
+    event MetaTransactionExecuted(
+        address userAddress,
+        address payable relayerAddress,
+        bytes functionSignature
+    );
+    mapping(address => uint256) nonces;
+
+    /*
+     * Meta transaction structure.
+     * No point of including value field here as if user is doing value transfer then he has the funds to pay for gas
+     * He should call the desired function directly in that case.
+     */
+    struct MetaTransaction {
+        uint256 nonce;
+        address from;
+        bytes functionSignature;
+    }
+
+    function executeMetaTransaction(
+        address userAddress,
+        bytes memory functionSignature,
+        bytes32 sigR,
+        bytes32 sigS,
+        uint8 sigV
+    ) public payable returns (bytes memory) {
+        MetaTransaction memory metaTx = MetaTransaction({
+            nonce: nonces[userAddress],
+            from: userAddress,
+            functionSignature: functionSignature
+        });
+
+        require(
+            verify(userAddress, metaTx, sigR, sigS, sigV),
+            "Signer and signature do not match"
+        );
+
+        // increase nonce for user (to avoid re-use)
+        nonces[userAddress] = nonces[userAddress].add(1);
+
+        emit MetaTransactionExecuted(
+            userAddress,
+            msg.sender,
+            functionSignature
+        );
+
+        // Append userAddress and relayer address at the end to extract it from calling context
+        (bool success, bytes memory returnData) = address(this).call(
+            abi.encodePacked(functionSignature, userAddress)
+        );
+        require(success, "Function call not successful");
+
+        return returnData;
+    }
+
+    function hashMetaTransaction(MetaTransaction memory metaTx)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                abi.encode(
+                    META_TRANSACTION_TYPEHASH,
+                    metaTx.nonce,
+                    metaTx.from,
+                    keccak256(metaTx.functionSignature)
+                )
+            );
+    }
+
+    function getNonce(address user) public view returns (uint256 nonce) {
+        nonce = nonces[user];
+    }
+
+    function verify(
+        address signer,
+        MetaTransaction memory metaTx,
+        bytes32 sigR,
+        bytes32 sigS,
+        uint8 sigV
+    ) internal view returns (bool) {
+        require(signer != address(0), "NativeMetaTransaction: INVALID_SIGNER");
+        return
+            signer ==
+            ecrecover(
+                toTypedMessageHash(hashMetaTransaction(metaTx)),
+                sigV,
+                sigR,
+                sigS
+            );
+    }
+}

--- a/polygon_contracts/UChildERC20.sol
+++ b/polygon_contracts/UChildERC20.sol
@@ -1,0 +1,80 @@
+pragma solidity 0.6.6;
+
+import "./ERC20.sol";
+import "./IChildToken.sol";
+import "./AccessControlMixin.sol";
+import "./NativeMetaTransaction.sol";
+import "./ChainConstants.sol";
+import "./ContextMixin.sol";
+
+contract UChildERC20 is
+    ERC20,
+    IChildToken,
+    AccessControlMixin,
+    NativeMetaTransaction,
+    ChainConstants,
+    ContextMixin
+{
+    bytes32 public constant DEPOSITOR_ROLE = keccak256("DEPOSITOR_ROLE");
+
+    constructor() public ERC20("", "") {}
+
+    /**
+     * @notice Initialize the contract after it has been proxified
+     * @dev meant to be called once immediately after deployment
+     */
+    function initialize(
+        string calldata name_,
+        string calldata symbol_,
+        uint8 decimals_,
+        address childChainManager
+    )
+        external
+        initializer
+    {
+      setName(name_);
+      setSymbol(symbol_);
+      setDecimals(decimals_);
+      _setupContractId(string(abi.encodePacked("Child", symbol_)));
+      _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+      _setupRole(DEPOSITOR_ROLE, childChainManager);
+      _initializeEIP712(name_, ERC712_VERSION);
+    }
+
+    // This is to support Native meta transactions
+    // never use msg.sender directly, use _msgSender() instead
+    function _msgSender()
+        internal
+        override
+        view
+        returns (address payable sender)
+    {
+        return ContextMixin.msgSender();
+    }
+
+    /**
+     * @notice called when token is deposited on root chain
+     * @dev Should be callable only by ChildChainManager
+     * Should handle deposit by minting the required amount for user
+     * Make sure minting is done only by this function
+     * @param user user address for whom deposit is being done
+     * @param depositData abi encoded amount
+     */
+    function deposit(address user, bytes calldata depositData)
+        external
+        override
+        only(DEPOSITOR_ROLE)
+    {
+        uint256 amount = abi.decode(depositData, (uint256));
+        _mint(user, amount);
+    }
+
+    /**
+     * @notice called when user wants to withdraw tokens back to root chain
+     * @dev Should burn user's tokens. This transaction will be verified when exiting on root chain
+     * @param amount amount of tokens to withdraw
+     */
+    function withdraw(uint256 amount) external {
+        _burn(_msgSender(), amount);
+    }
+}

--- a/polygon_contracts/proxy/IERCProxy.sol
+++ b/polygon_contracts/proxy/IERCProxy.sol
@@ -1,0 +1,7 @@
+pragma solidity 0.6.6;
+
+interface IERCProxy {
+    function proxyType() external pure returns (uint256 proxyTypeId);
+
+    function implementation() external view returns (address codeAddr);
+}

--- a/polygon_contracts/proxy/Proxy.sol
+++ b/polygon_contracts/proxy/Proxy.sol
@@ -1,0 +1,40 @@
+pragma solidity 0.6.6;
+
+import "./IERCProxy.sol";
+
+abstract contract Proxy is IERCProxy {
+    function delegatedFwd(address _dst, bytes memory _calldata) internal {
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            let result := delegatecall(
+                sub(gas(), 10000),
+                _dst,
+                add(_calldata, 0x20),
+                mload(_calldata),
+                0,
+                0
+            )
+            let size := returndatasize()
+
+            let ptr := mload(0x40)
+            returndatacopy(ptr, 0, size)
+
+            // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
+            // if the call returned error data, forward it
+            switch result
+                case 0 {
+                    revert(ptr, size)
+                }
+                default {
+                    return(ptr, size)
+                }
+        }
+    }
+
+    function proxyType() external virtual override pure returns (uint256 proxyTypeId) {
+        // Upgradeable proxy
+        proxyTypeId = 2;
+    }
+
+    function implementation() external virtual override view returns (address);
+}

--- a/polygon_contracts/proxy/UChildERC20Proxy.sol
+++ b/polygon_contracts/proxy/UChildERC20Proxy.sol
@@ -1,0 +1,10 @@
+pragma solidity 0.6.6;
+
+import "./UpgradableProxy.sol";
+
+contract UChildERC20Proxy is UpgradableProxy {
+    constructor(address _proxyTo)
+        public
+        UpgradableProxy(_proxyTo)
+    {}
+}

--- a/polygon_contracts/proxy/UpgradableProxy.sol
+++ b/polygon_contracts/proxy/UpgradableProxy.sol
@@ -1,0 +1,103 @@
+pragma solidity 0.6.6;
+
+import "./Proxy.sol";
+
+contract UpgradableProxy is Proxy {
+    event ProxyUpdated(address indexed _new, address indexed _old);
+    event ProxyOwnerUpdate(address _new, address _old);
+
+    bytes32 constant IMPLEMENTATION_SLOT = keccak256("matic.network.proxy.implementation");
+    bytes32 constant OWNER_SLOT = keccak256("matic.network.proxy.owner");
+
+    constructor(address _proxyTo) public {
+        setProxyOwner(msg.sender);
+        setImplementation(_proxyTo);
+    }
+
+    fallback() external payable {
+        delegatedFwd(loadImplementation(), msg.data);
+    }
+
+    receive() external payable {
+        delegatedFwd(loadImplementation(), msg.data);
+    }
+
+    modifier onlyProxyOwner() {
+        require(loadProxyOwner() == msg.sender, "NOT_OWNER");
+        _;
+    }
+
+    function proxyOwner() external view returns(address) {
+        return loadProxyOwner();
+    }
+
+    function loadProxyOwner() internal view returns(address) {
+        address _owner;
+        bytes32 position = OWNER_SLOT;
+        assembly {
+            _owner := sload(position)
+        }
+        return _owner;
+    }
+
+    function implementation() external override view returns (address) {
+        return loadImplementation();
+    }
+
+    function loadImplementation() internal view returns(address) {
+        address _impl;
+        bytes32 position = IMPLEMENTATION_SLOT;
+        assembly {
+            _impl := sload(position)
+        }
+        return _impl;
+    }
+
+    function transferProxyOwnership(address newOwner) public onlyProxyOwner {
+        require(newOwner != address(0), "ZERO_ADDRESS");
+        emit ProxyOwnerUpdate(newOwner, loadProxyOwner());
+        setProxyOwner(newOwner);
+    }
+
+    function setProxyOwner(address newOwner) private {
+        bytes32 position = OWNER_SLOT;
+        assembly {
+            sstore(position, newOwner)
+        }
+    }
+
+    function updateImplementation(address _newProxyTo) public onlyProxyOwner {
+        require(_newProxyTo != address(0x0), "INVALID_PROXY_ADDRESS");
+        require(isContract(_newProxyTo), "DESTINATION_ADDRESS_IS_NOT_A_CONTRACT");
+
+        emit ProxyUpdated(_newProxyTo, loadImplementation());
+        
+        setImplementation(_newProxyTo);
+    }
+
+    function updateAndCall(address _newProxyTo, bytes memory data) payable public onlyProxyOwner {
+        updateImplementation(_newProxyTo);
+
+        (bool success, bytes memory returnData) = address(this).call{value: msg.value}(data);
+        require(success, string(returnData));
+    }
+
+    function setImplementation(address _newProxyTo) private {
+        bytes32 position = IMPLEMENTATION_SLOT;
+        assembly {
+            sstore(position, _newProxyTo)
+        }
+    }
+    
+    function isContract(address _target) internal view returns (bool) {
+        if (_target == address(0)) {
+            return false;
+        }
+
+        uint256 size;
+        assembly {
+            size := extcodesize(_target)
+        }
+        return size > 0;
+    }
+}


### PR DESCRIPTION
Include Human Token smart contract code for the polygon mainnet

**References**: [Proxy](https://polygonscan.com/address/0xc748b2a084f8efc47e086ccddd9b7e67aeb571bf#code) and [Implementation](https://polygonscan.com/address/0x4948d86aa5f37fc07e3aa4a6f6f34f740b2752cc#code)

This is not configured to work with `hmt_escrow` python libraries nor tests. The purpose is to leave contracts here. Integration will be done in future pull requests

To compile and migrate with truffle, change next values in the `truffle.js`: `solc.version` = `0.6.6` and `evmVersion` = `istanbul`