### PR TITLE
Read Transfer event for transfer transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.14.1",
+    version="0.14.2",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",
@@ -14,5 +14,10 @@ setuptools.setup(
         "Programming Language :: Python",
     ],
     packages=setuptools.find_packages() + ["contracts", "migrations"],
-    install_requires=["hmt-basemodels==0.1.18", "boto3", "web3==5.24.0"],
+    install_requires=[
+        "boto3",
+        "cryptography",
+        "hmt-basemodels==0.1.18",
+        "web3==5.24.0",
+    ],
 )

--- a/test/hmt_escrow/test_job.py
+++ b/test/hmt_escrow/test_job.py
@@ -504,14 +504,14 @@ class JobTestCase(unittest.TestCase):
             "hmt_escrow.eth_bridge.sleep",
             sleep_mock
         ):
-            success = self.job._raffle_txn(
+            raffle_txn_res = self.job._raffle_txn(
                 multi_creds=[("1", "11")],
                 txn_func=txn_mock,
                 txn_args=[],
                 txn_event="Transfer",
             )
 
-            self.assertFalse(success)
+            self.assertFalse(raffle_txn_res["txn_succeeded"])
 
             self.assertEqual(
                 handler_mock.call_args_list,
@@ -533,14 +533,14 @@ class JobTestCase(unittest.TestCase):
             # no retries
             self.job.retry = Retry()
 
-            success = self.job._raffle_txn(
+            raffle_txn_res = self.job._raffle_txn(
                 multi_creds=[("1", "11")],
                 txn_func=txn_mock,
                 txn_args=[],
                 txn_event="Transfer",
             )
 
-            self.assertFalse(success)
+            self.assertFalse(raffle_txn_res["txn_succeeded"])
             self.assertEqual(
                 handler_mock.call_args_list,
                 [call(

--- a/test/hmt_escrow/test_utils.py
+++ b/test/hmt_escrow/test_utils.py
@@ -1,0 +1,71 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import hmt_escrow.utils as utils
+from hmt_escrow.eth_bridge import (
+    get_hmtoken,
+    handle_transaction,
+)
+
+from test.hmt_escrow.utils import create_job
+
+
+class UtilsTestCase(unittest.TestCase):
+    def setUp(self):
+        self.credentials = {
+            "gas_payer": "0x1413862C2B7054CDbfdc181B83962CB0FC11fD92",
+            "gas_payer_priv": "28e516f1e2f99e96a48a23cea1f94ee5f073403a1c68e818263f0eb898f1c8e5",
+        }
+        self.rep_oracle_pub_key = b"2dbc2c2c86052702e7c219339514b2e8bd4687ba1236c478ad41b43330b08488c12c8c1797aa181f3a4596a1bd8a0c18344ea44d6655f61fa73e56e743f79e0d"
+        self.job = create_job()
+
+    def test_parse_transfer_transaction_with_event_and_balance(self):
+        """ Test we return positive results for transaction with event and balance """
+        self.job.launch(self.rep_oracle_pub_key)
+        gas = 4712388
+        hmt_amount = int(self.job.amount * 10 ** 18)
+        hmtoken_contract = get_hmtoken()
+        txn_func = hmtoken_contract.functions.transfer
+        func_args = [self.job.job_contract.address, hmt_amount]
+        txn_info = {
+            "gas_payer": self.job.gas_payer,
+            "gas_payer_priv": self.job.gas_payer_priv,
+            "gas": gas,
+        }
+        txn_receipt = handle_transaction(txn_func, *func_args, **txn_info)
+
+        hmt_transferred, tx_balance = utils.parse_transfer_transaction(hmtoken_contract, txn_receipt)
+
+        self.assertTrue(hmt_transferred)
+        self.assertEqual(tx_balance, hmt_amount)
+    
+    def test_parse_transfer_transaction_without_event(self):
+        """ Test we return negative results for transaction with empty event """
+        hmtoken_contract = MagicMock()
+        tx_receipt = MagicMock()
+
+        hmtoken_contract.events = hmtoken_contract
+        hmtoken_contract.Transfer.return_value = hmtoken_contract
+        hmtoken_contract.processReceipt.side_effect = [()]
+
+        hmt_transferred, tx_balance = utils.parse_transfer_transaction(hmtoken_contract, tx_receipt)
+
+        self.assertFalse(hmt_transferred)
+        self.assertIsNone(tx_balance)
+
+    def test_parse_transfer_broken_transaction(self):
+        """ Test we return negative results for transaction not empty without balance """
+        hmtoken_contract = MagicMock()
+        tx_receipt = MagicMock()
+
+        hmtoken_contract.events = hmtoken_contract
+        hmtoken_contract.Transfer.return_value = hmtoken_contract
+        hmtoken_contract.processReceipt.side_effect = [
+            ({
+                "args": {}
+             },)
+        ]
+
+        hmt_transferred, tx_balance = utils.parse_transfer_transaction(hmtoken_contract, tx_receipt)
+
+        self.assertFalse(hmt_transferred)
+        self.assertIsNone(tx_balance)


### PR DESCRIPTION
The change fixes issue related to transfer tokens transaction.
Sometimes there is a valid transaction without event. In this case flag `hmt_transferred` will be `True`, but actually this is wrong `hmt_transferred` should be `False`. Changed code checks Transfer event of transaction and if it exists switches `hmt_transferred` to `True`.
Moreover `self.balance()` may also return wrong value if one of blockchain node still doesn't have information about transaction, code takes balance from `tx_receipt`.