### PR TITLE
feat: added subgraph deployment for moonbeam

### DIFF
--- a/.github/workflows/graph_deploy.yaml
+++ b/.github/workflows/graph_deploy.yaml
@@ -32,3 +32,6 @@ jobs:
       - run: node ./scripts/generatenetworkssubgraphs.js rinkeby
       - run: npm run codegen
       - run: graph deploy --product hosted-service humanprotocol/rinkeby
+      - run: node ./scripts/generatenetworkssubgraphs.js moonbeam
+      - run: npm run codegen
+      - run: graph deploy --product hosted-service humanprotocol/moonbeam

--- a/hmt_subgraph/networks.json
+++ b/hmt_subgraph/networks.json
@@ -22,5 +22,17 @@
       "address": "0x4dCf5ac4509888714dd43A5cCc46d7ab389D9c23",
       "startBlock": 7200306
     }
+  },
+  {
+    "name": "moonbeam",
+    "description": "Human subgraph on Moonbeam network",
+    "EscrowFactory": {
+      "address": "0x98108c28B7767a52BE38B4860832dd4e11A7ecad",
+      "startBlock": 1145429
+    },
+    "HMToken": {
+      "address": "0x3b25BC1dC591D24d60560d0135D6750A561D4764",
+      "startBlock": 1105853
+    }
   }
 ]


### PR DESCRIPTION
This PR resumes [humansubgraph PR #14](https://github.com/humanprotocol/humansubgraph/pull/14).

The foundation-controlled subgraph for moonbeam has already been created at https://thegraph.com/hosted-service/subgraph/humanprotocol/moonbeam