### PR TITLE
Query historical data from a GraphQL endpoint

### DIFF
--- a/hmt_subgraph/schema.graphql
+++ b/hmt_subgraph/schema.graphql
@@ -2,28 +2,28 @@ type LaunchedEscrow @entity {
   id: ID!
   eip20: Bytes! # address
   from: Bytes! # address
+  timestamp: BigInt!
 }
 
 type ISEvent @entity {
   id: ID!
-  count: BigInt!
+  timestamp: BigInt!
   _url: String! # string
   _hash: String! # string
 }
 
 type PEvent @entity {
   id: ID!
-  count: BigInt!
+  timestamp: BigInt!
   _url: String! # string
   _hash: String! # string
 }
 
 type BulkTransferEvent @entity {
   id: ID!
-  escrow: Bytes! # address 
+  escrow: Bytes! # address
   bulkCount: BigInt!
   txId: BigInt!
-  
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
@@ -34,16 +34,16 @@ type EscrowStatistics @entity {
   intermediateStorageEventCount: BigInt!
   pendingEventCount: BigInt!
   bulkTransferEventCount: BigInt!
+  totalEventCount: BigInt!
 }
-
 
 type HMTransferEvent @entity {
   id: ID!
-  token: Bytes! # address 
+  token: Bytes! # address
   from: Bytes! # address
   to: Bytes! # address
   value: BigInt!
-  
+
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
@@ -51,10 +51,10 @@ type HMTransferEvent @entity {
 
 type HMBulkTransferEvent @entity {
   id: ID!
-  
+
   bulkCount: BigInt!
   txId: BigInt!
-  
+
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
@@ -66,7 +66,6 @@ type HMApprovalEvent @entity {
   owner: Bytes! #address
   spender: Bytes! #address
   value: BigInt!
-
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
@@ -85,9 +84,7 @@ type HMBulkApprovalEvent @entity {
 
 type HMTokenStatistics @entity {
   id: ID!
-  transferEventCount: BigInt!
-  bulkTransferEventCount: BigInt!
-  approvalEventCount: BigInt!
-  bulkApprovalEventCount: BigInt!
+  totalTransferEventCount: BigInt!
+  totalValueTransfered: BigInt!
   token: Bytes! # token address
 }

--- a/hmt_subgraph/schema.graphql
+++ b/hmt_subgraph/schema.graphql
@@ -3,6 +3,7 @@ type LaunchedEscrow @entity {
   eip20: Bytes! # address
   from: Bytes! # address
   timestamp: BigInt!
+  count: BigInt
 }
 
 type ISEvent @entity {
@@ -10,6 +11,7 @@ type ISEvent @entity {
   timestamp: BigInt!
   _url: String! # string
   _hash: String! # string
+  count: BigInt
 }
 
 type PEvent @entity {
@@ -17,6 +19,7 @@ type PEvent @entity {
   timestamp: BigInt!
   _url: String! # string
   _hash: String! # string
+  count: BigInt
 }
 
 type BulkTransferEvent @entity {
@@ -27,6 +30,7 @@ type BulkTransferEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
+  count: BigInt
 }
 
 type EscrowStatistics @entity {
@@ -35,29 +39,29 @@ type EscrowStatistics @entity {
   pendingEventCount: BigInt!
   bulkTransferEventCount: BigInt!
   totalEventCount: BigInt!
+  totalEscrowCount: BigInt!
 }
 
 type HMTransferEvent @entity {
   id: ID!
   token: Bytes! # address
-  from: Bytes! # address
-  to: Bytes! # address
-  value: BigInt!
-
+  from: Bytes # address
+  to: Bytes # address
+  value: BigInt
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
+  count: BigInt
 }
 
 type HMBulkTransferEvent @entity {
   id: ID!
-
   bulkCount: BigInt!
   txId: BigInt!
-
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
+  count: BigInt
 }
 
 type HMApprovalEvent @entity {
@@ -69,22 +73,25 @@ type HMApprovalEvent @entity {
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
+  count: BigInt
 }
 
 type HMBulkApprovalEvent @entity {
   id: ID!
-
   bulkCount: BigInt!
   txId: BigInt!
-
   block: BigInt!
   timestamp: BigInt!
   transaction: Bytes!
+  count: BigInt
 }
 
 type HMTokenStatistics @entity {
   id: ID!
   totalTransferEventCount: BigInt!
+  totalApprovalEventCount: BigInt!
+  totalBulkApprovalEventCount: BigInt!
+  totalBulkTransferEventCount: BigInt!
   totalValueTransfered: BigInt!
   token: Bytes! # token address
 }

--- a/hmt_subgraph/src/mapping/Escrow.ts
+++ b/hmt_subgraph/src/mapping/Escrow.ts
@@ -12,13 +12,14 @@ import {
 import { BigInt } from "@graphprotocol/graph-ts";
 export const STATISTICS_ENTITY_ID = "escrow-statistics-id";
 
-function constructStatsEntity(): EscrowStatistics {
+export function constructStatsEntity(): EscrowStatistics {
   const entity = new EscrowStatistics(STATISTICS_ENTITY_ID);
 
   entity.intermediateStorageEventCount = BigInt.fromI32(0);
   entity.pendingEventCount = BigInt.fromI32(0);
   entity.bulkTransferEventCount = BigInt.fromI32(0);
   entity.totalEventCount = BigInt.fromI32(0);
+  entity.totalEscrowCount = BigInt.fromI32(0);
 
   return entity;
 }

--- a/hmt_subgraph/src/mapping/Escrow.ts
+++ b/hmt_subgraph/src/mapping/Escrow.ts
@@ -1,11 +1,15 @@
-import { BigInt } from "@graphprotocol/graph-ts";
 import {
   BulkTransfer,
   IntermediateStorage,
   Pending,
 } from "../../generated/templates/Escrow/Escrow";
-import { BulkTransferEvent, ISEvent, PEvent, EscrowStatistics } from "../../generated/schema";
-
+import {
+  BulkTransferEvent,
+  EscrowStatistics,
+  ISEvent,
+  PEvent,
+} from "../../generated/schema";
+import { BigInt } from "@graphprotocol/graph-ts";
 export const STATISTICS_ENTITY_ID = "escrow-statistics-id";
 
 function constructStatsEntity(): EscrowStatistics {
@@ -14,29 +18,21 @@ function constructStatsEntity(): EscrowStatistics {
   entity.intermediateStorageEventCount = BigInt.fromI32(0);
   entity.pendingEventCount = BigInt.fromI32(0);
   entity.bulkTransferEventCount = BigInt.fromI32(0);
+  entity.totalEventCount = BigInt.fromI32(0);
 
   return entity;
 }
-
 export function handleIntermediateStorage(event: IntermediateStorage): void {
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type
-  let id = event.transaction.from.toHex() + event.address.toHex();
-  let entity = ISEvent.load(id);
+  let id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
 
-  // Entities only exist after they have been saved to the store;
-  // `null` checks allow to create entities on demand
-  if (!entity) {
-    entity = new ISEvent(id);
-
-    // Entity fields can be set using simple assignments
-    entity.count = BigInt.fromI32(0);
-  }
-
-  // BigInt and BigDecimal math are supported // @ts-ignore
-  entity.count = entity.count + BigInt.fromI32(1);
+  let entity = new ISEvent(id);
 
   // Entity fields can be set based on event parameters
+  entity.timestamp = event.block.number;
   entity._url = event.params._url;
   entity._hash = event.params._hash;
 
@@ -48,7 +44,10 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
     statsEntity = constructStatsEntity();
   }
 
+  //@ts-ignore
   statsEntity.intermediateStorageEventCount += BigInt.fromI32(1);
+  //@ts-ignore
+  statsEntity.totalEventCount += BigInt.fromI32(1);
 
   statsEntity.save();
 }
@@ -56,25 +55,16 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
 export function handlePending(event: Pending): void {
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type
-  const id = event.transaction.from.toHex() + event.address.toHex();
-  let entity = PEvent.load(id);
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
 
-  // Entities only exist after they have been saved to the store;
-  // `null` checks allow to create entities on demand
-  if (!entity) {
-    entity = new PEvent(id);
-    // Entity fields can be set using simple assignments
-    entity.count = BigInt.fromI32(0);
-  }
-
-  // BigInt and BigDecimal math are supported
-  // @ts-ignore
-  entity.count = entity.count + BigInt.fromI32(1);
+  let entity = new PEvent(id);
 
   // Entity fields can be set based on event parameters
   entity._url = event.params.manifest;
   entity._hash = event.params.hash;
-
+  entity.timestamp = event.block.number;
   entity.save();
 
   let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);
@@ -83,40 +73,39 @@ export function handlePending(event: Pending): void {
     statsEntity = constructStatsEntity();
   }
 
+  //@ts-ignore
   statsEntity.pendingEventCount += BigInt.fromI32(1);
+  //@ts-ignore
+  statsEntity.totalEventCount += BigInt.fromI32(1);
 
   statsEntity.save();
 }
 
 export function handleBulkTransfer(event: BulkTransfer): void {
-  let entity = BulkTransferEvent.load(
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-  );
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
 
-  if (!entity) {
-    entity = new BulkTransferEvent(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-  }
+  let entity = new BulkTransferEvent(id);
 
   entity.escrow = event.address;
-
   entity.bulkCount = event.params._bulkCount;
   entity.txId = event.params._txId;
-
   entity.block = event.block.number;
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
 
   entity.save();
-
   let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);
 
   if (!statsEntity) {
     statsEntity = constructStatsEntity();
   }
 
+  //@ts-ignore
   statsEntity.bulkTransferEventCount += BigInt.fromI32(1);
+  //@ts-ignore
+  statsEntity.totalEventCount += BigInt.fromI32(1);
 
   statsEntity.save();
 }

--- a/hmt_subgraph/src/mapping/Escrow.ts
+++ b/hmt_subgraph/src/mapping/Escrow.ts
@@ -37,20 +37,20 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
   entity._url = event.params._url;
   entity._hash = event.params._hash;
 
-  entity.save();
-
   let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);
 
   if (!statsEntity) {
     statsEntity = constructStatsEntity();
   }
-
+  //@ts-ignore
+  entity.count = statsEntity.intermediateStorageEventCount + BigInt.fromI32(1);
   //@ts-ignore
   statsEntity.intermediateStorageEventCount += BigInt.fromI32(1);
   //@ts-ignore
   statsEntity.totalEventCount += BigInt.fromI32(1);
 
   statsEntity.save();
+  entity.save();
 }
 
 export function handlePending(event: Pending): void {
@@ -66,7 +66,6 @@ export function handlePending(event: Pending): void {
   entity._url = event.params.manifest;
   entity._hash = event.params.hash;
   entity.timestamp = event.block.timestamp;
-  entity.save();
 
   let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);
 
@@ -75,10 +74,13 @@ export function handlePending(event: Pending): void {
   }
 
   //@ts-ignore
+  entity.count = statsEntity.pendingEventCount + BigInt.fromI32(1);
+  //@ts-ignore
   statsEntity.pendingEventCount += BigInt.fromI32(1);
   //@ts-ignore
   statsEntity.totalEventCount += BigInt.fromI32(1);
 
+  entity.save();
   statsEntity.save();
 }
 
@@ -96,17 +98,18 @@ export function handleBulkTransfer(event: BulkTransfer): void {
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
 
-  entity.save();
   let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);
 
   if (!statsEntity) {
     statsEntity = constructStatsEntity();
   }
-
+  //@ts-ignore
+  entity.count = statsEntity.bulkTransferEventCount + BigInt.fromI32(1);
   //@ts-ignore
   statsEntity.bulkTransferEventCount += BigInt.fromI32(1);
   //@ts-ignore
   statsEntity.totalEventCount += BigInt.fromI32(1);
 
   statsEntity.save();
+  entity.save();
 }

--- a/hmt_subgraph/src/mapping/Escrow.ts
+++ b/hmt_subgraph/src/mapping/Escrow.ts
@@ -32,7 +32,7 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
   let entity = new ISEvent(id);
 
   // Entity fields can be set based on event parameters
-  entity.timestamp = event.block.number;
+  entity.timestamp = event.block.timestamp;
   entity._url = event.params._url;
   entity._hash = event.params._hash;
 
@@ -64,7 +64,7 @@ export function handlePending(event: Pending): void {
   // Entity fields can be set based on event parameters
   entity._url = event.params.manifest;
   entity._hash = event.params.hash;
-  entity.timestamp = event.block.number;
+  entity.timestamp = event.block.timestamp;
   entity.save();
 
   let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);

--- a/hmt_subgraph/src/mapping/EscrowFactory.ts
+++ b/hmt_subgraph/src/mapping/EscrowFactory.ts
@@ -1,6 +1,8 @@
+import { BigInt } from "@graphprotocol/graph-ts";
 import { Launched } from "../../generated/EscrowFactory/EscrowFactory";
-import { LaunchedEscrow } from "../../generated/schema";
+import { EscrowStatistics, LaunchedEscrow } from "../../generated/schema";
 import { Escrow } from "../../generated/templates";
+import { constructStatsEntity, STATISTICS_ENTITY_ID } from "./Escrow";
 
 export function handleLaunched(event: Launched): void {
   // Entities only exist after they have been saved to the store;
@@ -10,6 +12,17 @@ export function handleLaunched(event: Launched): void {
   entity.eip20 = event.params.eip20;
   entity.from = event.transaction.from;
   entity.timestamp = event.block.timestamp;
+
+  let statsEntity = EscrowStatistics.load(STATISTICS_ENTITY_ID);
+  if (!statsEntity) {
+    statsEntity = constructStatsEntity();
+  }
+  //@ts-ignore
+  entity.count = statsEntity.totalEscrowCount + BigInt.fromI32(1);
+  //@ts-ignore
+  statsEntity.totalEscrowCount += BigInt.fromI32(1);
+
+  statsEntity.save();
 
   // Entities can be written to the store with `.save()`
   entity.save();

--- a/hmt_subgraph/src/mapping/EscrowFactory.ts
+++ b/hmt_subgraph/src/mapping/EscrowFactory.ts
@@ -9,6 +9,7 @@ export function handleLaunched(event: Launched): void {
   // Entity fields can be set based on event parameters
   entity.eip20 = event.params.eip20;
   entity.from = event.transaction.from;
+  entity.timestamp = event.block.timestamp;
 
   // Entities can be written to the store with `.save()`
   entity.save();

--- a/hmt_subgraph/src/mapping/hm-token.ts
+++ b/hmt_subgraph/src/mapping/hm-token.ts
@@ -19,6 +19,9 @@ function constructStatsEntity(tokenAddress: Address): HMTokenStatistics {
   const entity = new HMTokenStatistics(HMT_STATISTICS_ENTITY_ID);
 
   entity.totalTransferEventCount = BigInt.fromI32(0);
+  entity.totalApprovalEventCount = BigInt.fromI32(0);
+  entity.totalBulkApprovalEventCount = BigInt.fromI32(0);
+  entity.totalBulkTransferEventCount = BigInt.fromI32(0);
   entity.totalValueTransfered = BigInt.fromI32(0);
   entity.token = tokenAddress;
 
@@ -33,21 +36,21 @@ export function handleTransfer(event: Transfer): void {
   let entity = new HMTransferEvent(id);
 
   entity.token = event.address;
-  entity.from = event.params._from;
-  entity.to = event.params._to;
-  entity.value = event.params._value;
+  entity.from = event.transaction.from;
+  entity.to = event.transaction.to;
+  entity.value = event.transaction.value;
 
   entity.block = event.block.number;
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
-
-  entity.save();
 
   let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
 
   if (!statsEntity) {
     statsEntity = constructStatsEntity(event.address);
   }
+  //@ts-ignore
+  entity.count = statsEntity.totalTransferEventCount + BigInt.fromI32(1);
 
   //@ts-ignore
   statsEntity.totalTransferEventCount += BigInt.fromI32(1);
@@ -55,6 +58,8 @@ export function handleTransfer(event: Transfer): void {
   statsEntity.totalValueTransfered += event.params._value;
 
   statsEntity.save();
+
+  entity.save();
 }
 
 export function handleBulkTransfer(event: BulkTransfer): void {
@@ -69,6 +74,18 @@ export function handleBulkTransfer(event: BulkTransfer): void {
   entity.block = event.block.number;
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
+
+  let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
+  if (!statsEntity) {
+    statsEntity = constructStatsEntity(event.address);
+  }
+  //@ts-ignore
+  entity.count = statsEntity.totalBulkTransferEventCount + BigInt.fromI32(1);
+
+  //@ts-ignore
+  statsEntity.totalBulkTransferEventCount += BigInt.fromI32(1);
+
+  statsEntity.save();
 
   entity.save();
 }
@@ -89,6 +106,18 @@ export function handleApproval(event: Approval): void {
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
 
+  let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
+  if (!statsEntity) {
+    statsEntity = constructStatsEntity(event.address);
+  }
+  //@ts-ignore
+  entity.count = statsEntity.totalApprovalEventCount + BigInt.fromI32(1);
+
+  //@ts-ignore
+  statsEntity.totalApprovalEventCount += BigInt.fromI32(1);
+
+  statsEntity.save();
+
   entity.save();
 }
 
@@ -105,6 +134,18 @@ export function handleBulkApproval(event: BulkApproval): void {
   entity.block = event.block.number;
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
+
+  let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
+  if (!statsEntity) {
+    statsEntity = constructStatsEntity(event.address);
+  }
+  //@ts-ignore
+  entity.count = statsEntity.totalBulkApprovalEventCount + BigInt.fromI32(1);
+
+  //@ts-ignore
+  statsEntity.totalBulkApprovalEventCount += BigInt.fromI32(1);
+
+  statsEntity.save();
 
   entity.save();
 }

--- a/hmt_subgraph/src/mapping/hm-token.ts
+++ b/hmt_subgraph/src/mapping/hm-token.ts
@@ -13,29 +13,25 @@ import {
   HMTokenStatistics,
 } from "../../generated/schema";
 
-export const HMT_STATISTICS_ENTITY_ID = 'hmt-statistics-1';
+export const HMT_STATISTICS_ENTITY_ID = "hmt-statistics-id";
 
 function constructStatsEntity(tokenAddress: Address): HMTokenStatistics {
   const entity = new HMTokenStatistics(HMT_STATISTICS_ENTITY_ID);
 
-  entity.transferEventCount = BigInt.fromI32(0);
-  entity.bulkTransferEventCount = BigInt.fromI32(0);
-  entity.approvalEventCount = BigInt.fromI32(0);
-  entity.bulkApprovalEventCount = BigInt.fromI32(0);
+  entity.totalTransferEventCount = BigInt.fromI32(0);
+  entity.totalValueTransfered = BigInt.fromI32(0);
   entity.token = tokenAddress;
 
   return entity;
 }
 
 export function handleTransfer(event: Transfer): void {
-  let entity = HMTransferEvent.load(
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-  );
-  if (!entity) {
-    entity = new HMTransferEvent(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-  }
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
+
+  let entity = new HMTransferEvent(id);
+
   entity.token = event.address;
   entity.from = event.params._from;
   entity.to = event.params._to;
@@ -53,51 +49,37 @@ export function handleTransfer(event: Transfer): void {
     statsEntity = constructStatsEntity(event.address);
   }
 
-  statsEntity.transferEventCount += BigInt.fromI32(1);
+  //@ts-ignore
+  statsEntity.totalTransferEventCount += BigInt.fromI32(1);
+  //@ts-ignore
+  statsEntity.totalValueTransfered += event.params._value;
 
   statsEntity.save();
 }
 
 export function handleBulkTransfer(event: BulkTransfer): void {
-  let entity = HMBulkTransferEvent.load(
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-  );
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
 
-  if (!entity) {
-    entity = new HMBulkTransferEvent(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-  }
+  let entity = new HMBulkTransferEvent(id);
 
   entity.bulkCount = event.params._bulkCount;
   entity.txId = event.params._txId;
-
   entity.block = event.block.number;
   entity.timestamp = event.block.timestamp;
   entity.transaction = event.transaction.hash;
 
   entity.save();
-
-  let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
-
-  if (!statsEntity) {
-    statsEntity = constructStatsEntity(event.address);
-  }
-
-  statsEntity.bulkTransferEventCount += BigInt.fromI32(1);
-
-  statsEntity.save();
 }
 
 export function handleApproval(event: Approval): void {
-  let entity = HMApprovalEvent.load(
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-  );
-  if (!entity) {
-    entity = new HMApprovalEvent(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-  }
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
+
+  let entity = new HMApprovalEvent(id);
+
   entity.token = event.address;
   entity.owner = event.params._owner;
   entity.spender = event.params._spender;
@@ -108,28 +90,14 @@ export function handleApproval(event: Approval): void {
   entity.transaction = event.transaction.hash;
 
   entity.save();
-
-  let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
-
-  if (!statsEntity) {
-    statsEntity = constructStatsEntity(event.address);
-  }
-
-  statsEntity.approvalEventCount += BigInt.fromI32(1);
-
-  statsEntity.save();
 }
 
 export function handleBulkApproval(event: BulkApproval): void {
-  let entity = HMBulkApprovalEvent.load(
-    event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-  );
+  const id = `${event.transaction.hash.toHex()}-${event.logIndex.toString()}-${
+    event.block.timestamp
+  }`;
 
-  if (!entity) {
-    entity = new HMBulkApprovalEvent(
-      event.transaction.hash.toHex() + "-" + event.logIndex.toString()
-    );
-  }
+  let entity = new HMBulkApprovalEvent(id);
 
   entity.bulkCount = event.params._bulkCount;
   entity.txId = event.params._txId;
@@ -139,14 +107,4 @@ export function handleBulkApproval(event: BulkApproval): void {
   entity.transaction = event.transaction.hash;
 
   entity.save();
-
-  let statsEntity = HMTokenStatistics.load(HMT_STATISTICS_ENTITY_ID);
-
-  if (!statsEntity) {
-    statsEntity = constructStatsEntity(event.address);
-  }
-
-  statsEntity.bulkApprovalEventCount += BigInt.fromI32(1);
-
-  statsEntity.save();
 }

--- a/hmt_subgraph/src/mapping/hm-token.ts
+++ b/hmt_subgraph/src/mapping/hm-token.ts
@@ -36,9 +36,9 @@ export function handleTransfer(event: Transfer): void {
   let entity = new HMTransferEvent(id);
 
   entity.token = event.address;
-  entity.from = event.transaction.from;
-  entity.to = event.transaction.to;
-  entity.value = event.transaction.value;
+  entity.from = event.params._from;
+  entity.to = event.params._to;
+  entity.value = event.params._value;
 
   entity.block = event.block.number;
   entity.timestamp = event.block.timestamp;

--- a/hmt_subgraph/subgraph.yaml
+++ b/hmt_subgraph/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     network: matic
     source:
       abi: EscrowFactory
-      address: '0x45eBc3eAE6DA485097054ae10BA1A0f8e8c7f794'
+      address: "0x45eBc3eAE6DA485097054ae10BA1A0f8e8c7f794"
       startBlock: 25426565
     mapping:
       kind: ethereum/events
@@ -28,7 +28,7 @@ dataSources:
     network: matic
     source:
       abi: HMToken
-      address: '0xc748B2A084F8eFc47E086ccdDD9b7e67aEb571Bf'
+      address: "0xc748B2A084F8eFc47E086ccdDD9b7e67aEb571Bf"
       startBlock: 20181700
     mapping:
       kind: ethereum/events

--- a/hmt_subgraph/subgraph.yaml
+++ b/hmt_subgraph/subgraph.yaml
@@ -50,6 +50,7 @@ dataSources:
         - event: BulkTransfer(indexed uint256,uint256)
           handler: handleBulkTransfer
         - event: Transfer(indexed address,indexed address,uint256)
+
           handler: handleTransfer
       file: ./src/mapping/hm-token.ts
 templates:

--- a/hmt_subgraph/tests/escrow/escrow.test.ts
+++ b/hmt_subgraph/tests/escrow/escrow.test.ts
@@ -99,8 +99,8 @@ describe("EscrowStatistics entity", () => {
   });
 
   test("Should properly calculate BulkTransfser event in statistics", () => {
-    let bulkEvent1 = createBulkTransferEvent(1, 5);
-    let bulkEvent2 = createBulkTransferEvent(2, 4);
+    let bulkEvent1 = createBulkTransferEvent(1, 5, BigInt.fromI32(11));
+    let bulkEvent2 = createBulkTransferEvent(2, 4, BigInt.fromI32(11));
 
     handleBulkTransfer(bulkEvent1);
     handleBulkTransfer(bulkEvent2);
@@ -122,6 +122,91 @@ describe("EscrowStatistics entity", () => {
       STATISTICS_ENTITY_ID,
       "bulkTransferEventCount",
       "2"
+    );
+
+    clearStore();
+  });
+});
+
+describe("Escrow entity", () => {
+  test("Should properly index bulk transfers", () => {
+    let bulk1 = createBulkTransferEvent(1, 2, BigInt.fromI32(10));
+    let bulk2 = createBulkTransferEvent(3, 4, BigInt.fromI32(11));
+
+    handleBulkTransfer(bulk1);
+    handleBulkTransfer(bulk2);
+
+    const id1 = `${bulk1.transaction.hash.toHex()}-${bulk1.logIndex.toString()}-${
+      bulk1.block.timestamp
+    }`;
+    const id2 = `${bulk2.transaction.hash.toHex()}-${bulk2.logIndex.toString()}-${
+      bulk2.block.timestamp
+    }`;
+
+    // Bulk 1
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id1,
+      "timestamp",
+      bulk1.block.timestamp.toString()
+    );
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id1,
+      "block",
+      bulk1.block.number.toString()
+    );
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id1,
+      "bulkCount",
+      bulk1.params._bulkCount.toString()
+    );
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id1,
+      "txId",
+      bulk1.params._txId.toString()
+    );
+
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id1,
+      "transaction",
+      bulk1.transaction.hash.toHexString()
+    );
+
+    // Bulk 2
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id2,
+      "timestamp",
+      bulk2.block.timestamp.toString()
+    );
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id2,
+      "block",
+      bulk2.block.number.toString()
+    );
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id2,
+      "bulkCount",
+      bulk2.params._bulkCount.toString()
+    );
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id2,
+      "txId",
+      bulk2.params._txId.toString()
+    );
+
+    assert.fieldEquals(
+      "BulkTransferEvent",
+      id2,
+      "transaction",
+      bulk2.transaction.hash.toHexString()
     );
 
     clearStore();

--- a/hmt_subgraph/tests/escrow/escrow.test.ts
+++ b/hmt_subgraph/tests/escrow/escrow.test.ts
@@ -27,11 +27,13 @@ describe("Generic Entity case", () => {
     const intermediateStorageEvent = new ISEvent(DUMMY_ID);
     intermediateStorageEvent.timestamp = BigInt.fromI32(10000);
     intermediateStorageEvent._url = "test.com";
+    intermediateStorageEvent.count = BigInt.fromI32(1);
     intermediateStorageEvent._hash = "testhash";
 
     intermediateStorageEvent.save();
 
     assert.fieldEquals("ISEvent", DUMMY_ID, "timestamp", "10000");
+    assert.fieldEquals("ISEvent", DUMMY_ID, "count", "1");
     assert.fieldEquals("ISEvent", DUMMY_ID, "_url", "test.com");
     assert.fieldEquals("ISEvent", DUMMY_ID, "_hash", "testhash");
 
@@ -99,11 +101,8 @@ describe("EscrowStatistics entity", () => {
   });
 
   test("Should properly calculate BulkTransfser event in statistics", () => {
-    let bulkEvent1 = createBulkTransferEvent(1, 5, BigInt.fromI32(11));
-    let bulkEvent2 = createBulkTransferEvent(2, 4, BigInt.fromI32(11));
-
-    handleBulkTransfer(bulkEvent1);
-    handleBulkTransfer(bulkEvent2);
+    handleBulkTransfer(createBulkTransferEvent(1, 5, BigInt.fromI32(11)));
+    handleBulkTransfer(createBulkTransferEvent(2, 4, BigInt.fromI32(11)));
 
     assert.fieldEquals(
       "EscrowStatistics",

--- a/hmt_subgraph/tests/escrow/escrow.test.ts
+++ b/hmt_subgraph/tests/escrow/escrow.test.ts
@@ -1,29 +1,43 @@
-import { describe, test, assert, clearStore } from "matchstick-as/assembly/index";
-import { store, BigInt } from "@graphprotocol/graph-ts"
-
+import {
+  describe,
+  test,
+  assert,
+  clearStore,
+} from "matchstick-as/assembly/index";
+import { store, BigInt } from "@graphprotocol/graph-ts";
 
 import { ISEvent } from "../../generated/schema";
-import { IntermediateStorage, Pending, BulkTransfer } from "../../generated/templates/Escrow/Escrow";
-import { handleIntermediateStorage, handlePending, handleBulkTransfer, STATISTICS_ENTITY_ID } from "../../src/mapping/Escrow";
-import { createISEvent, createPendingEvent, createBulkTransferEvent } from './fixtures';
+
+import {
+  handleIntermediateStorage,
+  handlePending,
+  handleBulkTransfer,
+  STATISTICS_ENTITY_ID,
+} from "../../src/mapping/Escrow";
+import {
+  createISEvent,
+  createPendingEvent,
+  createBulkTransferEvent,
+} from "./fixtures";
 
 describe("Generic Entity case", () => {
   test("Should correctly get ISEvents entity details", () => {
     const DUMMY_ID = "0x0-0x0";
 
     const intermediateStorageEvent = new ISEvent(DUMMY_ID);
-    intermediateStorageEvent.count = BigInt.fromString('1');
+    intermediateStorageEvent.timestamp = BigInt.fromI32(10000);
     intermediateStorageEvent._url = "test.com";
     intermediateStorageEvent._hash = "testhash";
 
     intermediateStorageEvent.save();
-    assert.fieldEquals("ISEvent", DUMMY_ID, "count", '1');
+
+    assert.fieldEquals("ISEvent", DUMMY_ID, "timestamp", "10000");
     assert.fieldEquals("ISEvent", DUMMY_ID, "_url", "test.com");
     assert.fieldEquals("ISEvent", DUMMY_ID, "_hash", "testhash");
 
     store.remove("ISEvent", DUMMY_ID);
   });
-})
+});
 
 describe("EscrowStatistics entity", () => {
   test("Should properly calculate IntermediateStorage event in statistics", () => {
@@ -33,9 +47,24 @@ describe("EscrowStatistics entity", () => {
     handleIntermediateStorage(newIS);
     handleIntermediateStorage(newIS1);
 
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "pendingEventCount", '0');
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "intermediateStorageEventCount", '2');
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "bulkTransferEventCount", '0');
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "pendingEventCount",
+      "0"
+    );
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "intermediateStorageEventCount",
+      "2"
+    );
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "bulkTransferEventCount",
+      "0"
+    );
 
     clearStore();
   });
@@ -47,9 +76,24 @@ describe("EscrowStatistics entity", () => {
     handlePending(newPending1);
     handlePending(newPending2);
 
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "pendingEventCount", '2');
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "intermediateStorageEventCount", '0');
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "bulkTransferEventCount", '0');
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "pendingEventCount",
+      "2"
+    );
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "intermediateStorageEventCount",
+      "0"
+    );
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "bulkTransferEventCount",
+      "0"
+    );
 
     clearStore();
   });
@@ -61,9 +105,24 @@ describe("EscrowStatistics entity", () => {
     handleBulkTransfer(bulkEvent1);
     handleBulkTransfer(bulkEvent2);
 
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "pendingEventCount", '0');
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "intermediateStorageEventCount", '0');
-    assert.fieldEquals("EscrowStatistics", STATISTICS_ENTITY_ID, "bulkTransferEventCount", '2');
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "pendingEventCount",
+      "0"
+    );
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "intermediateStorageEventCount",
+      "0"
+    );
+    assert.fieldEquals(
+      "EscrowStatistics",
+      STATISTICS_ENTITY_ID,
+      "bulkTransferEventCount",
+      "2"
+    );
 
     clearStore();
   });

--- a/hmt_subgraph/tests/escrow/fixtures.ts
+++ b/hmt_subgraph/tests/escrow/fixtures.ts
@@ -1,13 +1,25 @@
 import { newMockEvent } from "matchstick-as/assembly/index";
-import { ethereum, BigInt } from "@graphprotocol/graph-ts"
+import { ethereum, BigInt } from "@graphprotocol/graph-ts";
 
-import { IntermediateStorage, Pending, BulkTransfer } from "../../generated/templates/Escrow/Escrow";
+import {
+  IntermediateStorage,
+  Pending,
+  BulkTransfer,
+} from "../../generated/templates/Escrow/Escrow";
 
 export function createISEvent(url: string, hash: string): IntermediateStorage {
-  let newIntermediateStorageEvent = changetype<IntermediateStorage>(newMockEvent());
+  let newIntermediateStorageEvent = changetype<IntermediateStorage>(
+    newMockEvent()
+  );
   newIntermediateStorageEvent.parameters = new Array();
-  let urlParam = new ethereum.EventParam("_url", ethereum.Value.fromString(url));
-  let hashParam = new ethereum.EventParam("_hash", ethereum.Value.fromString(hash));
+  let urlParam = new ethereum.EventParam(
+    "_url",
+    ethereum.Value.fromString(url)
+  );
+  let hashParam = new ethereum.EventParam(
+    "_hash",
+    ethereum.Value.fromString(hash)
+  );
 
   newIntermediateStorageEvent.parameters.push(urlParam);
   newIntermediateStorageEvent.parameters.push(hashParam);
@@ -18,8 +30,14 @@ export function createISEvent(url: string, hash: string): IntermediateStorage {
 export function createPendingEvent(manifest: string, hash: string): Pending {
   let newPendingEvent = changetype<Pending>(newMockEvent());
   newPendingEvent.parameters = new Array();
-  let manifestParam = new ethereum.EventParam("manifest", ethereum.Value.fromString(manifest));
-  let hashParam = new ethereum.EventParam("hash", ethereum.Value.fromString(hash));
+  let manifestParam = new ethereum.EventParam(
+    "manifest",
+    ethereum.Value.fromString(manifest)
+  );
+  let hashParam = new ethereum.EventParam(
+    "hash",
+    ethereum.Value.fromString(hash)
+  );
 
   newPendingEvent.parameters.push(manifestParam);
   newPendingEvent.parameters.push(hashParam);
@@ -27,15 +45,25 @@ export function createPendingEvent(manifest: string, hash: string): Pending {
   return newPendingEvent;
 }
 
-export function createBulkTransferEvent(txId: i32, bulkCount: i32): BulkTransfer {
+export function createBulkTransferEvent(
+  txId: i32,
+  bulkCount: i32,
+  timestamp: BigInt
+): BulkTransfer {
   let newBTEvent = changetype<BulkTransfer>(newMockEvent());
   newBTEvent.parameters = new Array();
-  let txIdParam = new ethereum.EventParam("_txId", ethereum.Value.fromI32(txId));
-  let bulkCountParam = new ethereum.EventParam("hash", ethereum.Value.fromI32(bulkCount));
+  newBTEvent.block.timestamp = timestamp;
+  let txIdParam = new ethereum.EventParam(
+    "_txId",
+    ethereum.Value.fromI32(txId)
+  );
+  let bulkCountParam = new ethereum.EventParam(
+    "hash",
+    ethereum.Value.fromI32(bulkCount)
+  );
 
   newBTEvent.parameters.push(txIdParam);
   newBTEvent.parameters.push(bulkCountParam);
 
   return newBTEvent;
 }
-

--- a/hmt_subgraph/tests/hmt/fixtures.ts
+++ b/hmt_subgraph/tests/hmt/fixtures.ts
@@ -3,12 +3,27 @@ import { Address, ethereum, BigInt } from "@graphprotocol/graph-ts";
 
 import { Transfer, Approval } from "../../generated/HMToken/HMToken";
 
-export function createTransferEvent(from: string, to: string, value: i32): Transfer {
+export function createTransferEvent(
+  from: string,
+  to: string,
+  value: i32,
+  timestamp: BigInt
+): Transfer {
   let transferEvent = changetype<Transfer>(newMockEvent());
   transferEvent.parameters = new Array();
-  let fromParam = new ethereum.EventParam("_from", ethereum.Value.fromAddress(Address.fromString(from)));
-  let toParam = new ethereum.EventParam("_to", ethereum.Value.fromAddress(Address.fromString(to)));
-  let valueParam = new ethereum.EventParam("_value", ethereum.Value.fromI32(value));
+  transferEvent.block.timestamp = timestamp;
+  let fromParam = new ethereum.EventParam(
+    "_from",
+    ethereum.Value.fromAddress(Address.fromString(from))
+  );
+  let toParam = new ethereum.EventParam(
+    "_to",
+    ethereum.Value.fromAddress(Address.fromString(to))
+  );
+  let valueParam = new ethereum.EventParam(
+    "_value",
+    ethereum.Value.fromI32(value)
+  );
 
   transferEvent.parameters.push(fromParam);
   transferEvent.parameters.push(toParam);
@@ -17,12 +32,27 @@ export function createTransferEvent(from: string, to: string, value: i32): Trans
   return transferEvent;
 }
 
-export function createApprovalEvent(spender: string, owner: string, value: i32): Approval {
+export function createApprovalEvent(
+  spender: string,
+  owner: string,
+  value: i32,
+  timestamp: BigInt
+): Approval {
   let approvalEvent = changetype<Approval>(newMockEvent());
   approvalEvent.parameters = new Array();
-  let ownerParam = new ethereum.EventParam("_spender", ethereum.Value.fromAddress(Address.fromString(spender)));
-  let spenderParam = new ethereum.EventParam("_owner", ethereum.Value.fromAddress(Address.fromString(owner)));
-  let valueParam = new ethereum.EventParam("_value", ethereum.Value.fromI32(value));
+  approvalEvent.block.timestamp = timestamp;
+  let ownerParam = new ethereum.EventParam(
+    "_spender",
+    ethereum.Value.fromAddress(Address.fromString(spender))
+  );
+  let spenderParam = new ethereum.EventParam(
+    "_owner",
+    ethereum.Value.fromAddress(Address.fromString(owner))
+  );
+  let valueParam = new ethereum.EventParam(
+    "_value",
+    ethereum.Value.fromI32(value)
+  );
 
   approvalEvent.parameters.push(ownerParam);
   approvalEvent.parameters.push(spenderParam);

--- a/hmt_subgraph/tests/hmt/hmt.test.ts
+++ b/hmt_subgraph/tests/hmt/hmt.test.ts
@@ -8,7 +8,6 @@ import {
 
 import {
   handleApproval,
-  handleBulkTransfer,
   handleTransfer,
   HMT_STATISTICS_ENTITY_ID,
 } from "../../src/mapping/hm-token";
@@ -112,6 +111,7 @@ describe("HMToken entity", () => {
       "transaction",
       transfer1.transaction.hash.toHexString()
     );
+    assert.fieldEquals("HMTransferEvent", id1, "count", "1");
 
     // Trasnfer 2
     assert.fieldEquals("HMTransferEvent", id2, "timestamp", "11");
@@ -151,6 +151,7 @@ describe("HMToken entity", () => {
       "transaction",
       transfer2.transaction.hash.toHexString()
     );
+    assert.fieldEquals("HMTransferEvent", id2, "count", "2");
 
     clearStore();
   });
@@ -218,6 +219,7 @@ describe("HMToken entity", () => {
       "transaction",
       approval1.transaction.hash.toHexString()
     );
+    assert.fieldEquals("HMApprovalEvent", id1, "count", "1");
 
     // Trasnfer 2
     assert.fieldEquals("HMApprovalEvent", id2, "timestamp", "11");
@@ -257,7 +259,7 @@ describe("HMToken entity", () => {
       "transaction",
       approval2.transaction.hash.toHexString()
     );
-
+    assert.fieldEquals("HMApprovalEvent", id2, "count", "2");
     clearStore();
   });
 });

--- a/hmt_subgraph/tests/hmt/hmt.test.ts
+++ b/hmt_subgraph/tests/hmt/hmt.test.ts
@@ -1,3 +1,4 @@
+import { BigInt } from "@graphprotocol/graph-ts";
 import {
   describe,
   test,
@@ -6,22 +7,26 @@ import {
 } from "matchstick-as/assembly/index";
 
 import {
+  handleApproval,
+  handleBulkTransfer,
   handleTransfer,
   HMT_STATISTICS_ENTITY_ID,
 } from "../../src/mapping/hm-token";
-import { createTransferEvent } from "./fixtures";
+import { createApprovalEvent, createTransferEvent } from "./fixtures";
 
 describe("HMToken entity", () => {
   test("Should properly calculate Transfer event in statistics", () => {
     let transfer1 = createTransferEvent(
       "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
       "0x92a2eEF7Ff696BCef98957a0189872680600a959",
-      1
+      1,
+      BigInt.fromI32(10)
     );
     let transfer2 = createTransferEvent(
       "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
       "0x92a2eEF7Ff696BCef98957a0189872680600a959",
-      2
+      2,
+      BigInt.fromI32(10)
     );
 
     handleTransfer(transfer1);
@@ -38,6 +43,219 @@ describe("HMToken entity", () => {
       HMT_STATISTICS_ENTITY_ID,
       "totalValueTransfered",
       "3"
+    );
+
+    clearStore();
+  });
+});
+
+describe("HMToken entity", () => {
+  test("Should properly index Transfer events", () => {
+    let transfer1 = createTransferEvent(
+      "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
+      "0x92a2eEF7Ff696BCef98957a0189872680600a959",
+      1,
+      BigInt.fromI32(10)
+    );
+    let transfer2 = createTransferEvent(
+      "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
+      "0x92a2eEF7Ff696BCef98957a0189872680600a959",
+      2,
+      BigInt.fromI32(11)
+    );
+
+    handleTransfer(transfer1);
+    handleTransfer(transfer2);
+
+    const id1 = `${transfer1.transaction.hash.toHex()}-${transfer1.logIndex.toString()}-${
+      transfer1.block.timestamp
+    }`;
+    const id2 = `${transfer2.transaction.hash.toHex()}-${transfer2.logIndex.toString()}-${
+      transfer2.block.timestamp
+    }`;
+
+    // Trasnfer 1
+    assert.fieldEquals("HMTransferEvent", id1, "timestamp", "10");
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id1,
+      "block",
+      transfer1.block.number.toString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id1,
+      "token",
+      transfer1.address.toHexString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id1,
+      "from",
+      transfer1.params._from.toHexString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id1,
+      "to",
+      transfer1.params._to.toHexString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id1,
+      "value",
+      transfer1.params._value.toString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id1,
+      "transaction",
+      transfer1.transaction.hash.toHexString()
+    );
+
+    // Trasnfer 2
+    assert.fieldEquals("HMTransferEvent", id2, "timestamp", "11");
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id2,
+      "block",
+      transfer2.block.number.toString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id2,
+      "token",
+      transfer2.address.toHexString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id2,
+      "from",
+      transfer2.params._from.toHexString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id2,
+      "to",
+      transfer2.params._to.toHexString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id2,
+      "value",
+      transfer2.params._value.toString()
+    );
+    assert.fieldEquals(
+      "HMTransferEvent",
+      id2,
+      "transaction",
+      transfer2.transaction.hash.toHexString()
+    );
+
+    clearStore();
+  });
+});
+describe("HMToken entity", () => {
+  test("Should properly index approval events", () => {
+    let approval1 = createApprovalEvent(
+      "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
+      "0x92a2eEF7Ff696BCef98957a0189872680600a959",
+      1,
+      BigInt.fromI32(10)
+    );
+    let approval2 = createApprovalEvent(
+      "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
+      "0x92a2eEF7Ff696BCef98957a0189872680600a959",
+      2,
+      BigInt.fromI32(11)
+    );
+
+    handleApproval(approval1);
+    handleApproval(approval2);
+
+    const id1 = `${approval1.transaction.hash.toHex()}-${approval1.logIndex.toString()}-${
+      approval1.block.timestamp
+    }`;
+    const id2 = `${approval2.transaction.hash.toHex()}-${approval2.logIndex.toString()}-${
+      approval2.block.timestamp
+    }`;
+
+    // Trasnfer 1
+    assert.fieldEquals("HMApprovalEvent", id1, "timestamp", "10");
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id1,
+      "block",
+      approval1.block.number.toString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id1,
+      "token",
+      approval1.address.toHexString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id1,
+      "spender",
+      approval1.params._spender.toHexString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id1,
+      "owner",
+      approval1.params._owner.toHexString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id1,
+      "value",
+      approval1.params._value.toString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id1,
+      "transaction",
+      approval1.transaction.hash.toHexString()
+    );
+
+    // Trasnfer 2
+    assert.fieldEquals("HMApprovalEvent", id2, "timestamp", "11");
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id2,
+      "block",
+      approval2.block.number.toString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id2,
+      "token",
+      approval2.address.toHexString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id2,
+      "owner",
+      approval2.params._owner.toHexString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id2,
+      "spender",
+      approval2.params._spender.toHexString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id2,
+      "value",
+      approval2.params._value.toString()
+    );
+    assert.fieldEquals(
+      "HMApprovalEvent",
+      id2,
+      "transaction",
+      approval2.transaction.hash.toHexString()
     );
 
     clearStore();

--- a/hmt_subgraph/tests/hmt/hmt.test.ts
+++ b/hmt_subgraph/tests/hmt/hmt.test.ts
@@ -1,39 +1,44 @@
-import { describe, test, assert, clearStore } from "matchstick-as/assembly/index";
-import { store, BigInt } from "@graphprotocol/graph-ts"
+import {
+  describe,
+  test,
+  assert,
+  clearStore,
+} from "matchstick-as/assembly/index";
 
-
-import { HMTransferEvent } from "../../generated/schema";
-import { Transfer, Approval } from "../../generated/HMToken/HMToken";
-import { handleTransfer, handleApproval, HMT_STATISTICS_ENTITY_ID } from "../../src/mapping/hm-token";
-import { createTransferEvent, createApprovalEvent } from './fixtures';
+import {
+  handleTransfer,
+  HMT_STATISTICS_ENTITY_ID,
+} from "../../src/mapping/hm-token";
+import { createTransferEvent } from "./fixtures";
 
 describe("HMToken entity", () => {
   test("Should properly calculate Transfer event in statistics", () => {
-    let transfer1 = createTransferEvent("0xD979105297fB0eee83F7433fC09279cb5B94fFC6", "0x92a2eEF7Ff696BCef98957a0189872680600a959", 1);
-    let transfer2 = createTransferEvent("0xD979105297fB0eee83F7433fC09279cb5B94fFC6", "0x92a2eEF7Ff696BCef98957a0189872680600a959", 2);
+    let transfer1 = createTransferEvent(
+      "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
+      "0x92a2eEF7Ff696BCef98957a0189872680600a959",
+      1
+    );
+    let transfer2 = createTransferEvent(
+      "0xD979105297fB0eee83F7433fC09279cb5B94fFC6",
+      "0x92a2eEF7Ff696BCef98957a0189872680600a959",
+      2
+    );
 
     handleTransfer(transfer1);
     handleTransfer(transfer2);
 
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "transferEventCount", '2');
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "bulkTransferEventCount", '0');
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "approvalEventCount", '0');
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "bulkApprovalEventCount", '0');
-
-    clearStore();
-  });
-
-  test("Should properly calculate Approval event in statistics", () => {
-    let transfer1 = createApprovalEvent("0xD979105297fB0eee83F7433fC09279cb5B94fFC6", "0x92a2eEF7Ff696BCef98957a0189872680600a959", 1);
-    let transfer2 = createApprovalEvent("0xD979105297fB0eee83F7433fC09279cb5B94fFC6", "0x92a2eEF7Ff696BCef98957a0189872680600a959", 2);
-
-    handleApproval(transfer1);
-    handleApproval(transfer2);
-
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "transferEventCount", '0');
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "bulkTransferEventCount", '0');
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "approvalEventCount", '2');
-    assert.fieldEquals("HMTokenStatistics", HMT_STATISTICS_ENTITY_ID, "bulkApprovalEventCount", '0');
+    assert.fieldEquals(
+      "HMTokenStatistics",
+      HMT_STATISTICS_ENTITY_ID,
+      "totalTransferEventCount",
+      "2"
+    );
+    assert.fieldEquals(
+      "HMTokenStatistics",
+      HMT_STATISTICS_ENTITY_ID,
+      "totalValueTransfered",
+      "3"
+    );
 
     clearStore();
   });


### PR DESCRIPTION

Modified schemas and indexation to query historical data (wrt time) from a GraphQL endpoint for the following elements:

- [x]  Amount Of Escrows
Example : get escrows launched between 4 September 2022 00:00 and 5 September 2022 00:00
```
{
  launchedEscrows(
    where: {  timestamp_gte: 1662249600, timestamp_lte: 1662336000}
  ) {
    id
  }
}
```
- [x]  All Escrows Pending Events
Example : get escrows pending events between 4 September 2022 00:00 and 5 September 2022 00:00
```
{
  pevents(
    where: {  timestamp_gte: 1662249600, timestamp_lte: 1662336000}
  ) {
    id
  }
}
```
- [x]  All Escrows BulkTransfer Events
Example : get escrows bulkTransers events between 4 September 2022 00:00 and 5 September 2022 00:00
```
{
  bulkTransferEvents(
    where: {  timestamp_gte: 1662249600, timestamp_lte: 1662336000}
  ) {
    id
  }
}
```
- [x]  All Escrows Intermediate Storage Events
Example : get escrows Intermediate events between 4 September 2022 00:00 and 5 September 2022 00:00
```
{
  isevents(
    where: {  timestamp_gte: 1662249600, timestamp_lte: 1662336000}
  ) {
    id
  }
}
```

Total Number Of Escrow Events for the following networks:

- [x]  Polygon Mainnet
- [ ]  Polygon Mumbai Testnet
- [X]  Ethereum Rinkeby
- [ ]  Neons Lab Devtestnet

**Mumbai and Neons Lab Devtestnet are not yet indexed, contracts for these BC has been already deployed ?** 

Also, query the following token data:

- [X]  Token Transfers
Query to get the total of token transfers 
```
{
   hmtokenStatistics(id: "hmt-statistics-id") {
    totalTransferEventCount
  }
}
```
- [x]  Token Price **(Not indexed on the graph, must be fetch with coingecko API)**
- [x]  Token Amount of transfers
Queries to get the total value transfered 
```
{
   hmtokenStatistics(id: "hmt-statistics-id") {
    totalValueTransfered
  }
}
```
- [x]  Token Holders **(Not indexed on the graph, must be fetch with scan API)**