### PR TITLE
feat: add eventDayDatas

### DIFF
--- a/hmt_subgraph/schema.graphql
+++ b/hmt_subgraph/schema.graphql
@@ -95,3 +95,12 @@ type HMTokenStatistics @entity {
   totalValueTransfered: BigInt!
   token: Bytes! # token address
 }
+
+type EventDayData @entity {
+  id: ID!
+  timestamp: Int!
+  dailyBulkTransferEvents: BigInt!
+  dailyIntermediateStorageEvents: BigInt!
+  dailyPendingEvents: BigInt!
+  dailyEscrowAmounts: BigInt!
+}

--- a/hmt_subgraph/src/mapping/Escrow.ts
+++ b/hmt_subgraph/src/mapping/Escrow.ts
@@ -10,6 +10,11 @@ import {
   PEvent,
 } from "../../generated/schema";
 import { BigInt } from "@graphprotocol/graph-ts";
+import {
+  updateIntermediateStorageEventDayData,
+  updatePendingEventDayData,
+  updateBulkTransferEventDayData,
+} from "./utils/dayUpdates";
 export const STATISTICS_ENTITY_ID = "escrow-statistics-id";
 
 export function constructStatsEntity(): EscrowStatistics {
@@ -23,6 +28,7 @@ export function constructStatsEntity(): EscrowStatistics {
 
   return entity;
 }
+
 export function handleIntermediateStorage(event: IntermediateStorage): void {
   // Entities can be loaded from the store using a string ID; this ID
   // needs to be unique across all entities of the same type
@@ -51,6 +57,8 @@ export function handleIntermediateStorage(event: IntermediateStorage): void {
 
   statsEntity.save();
   entity.save();
+
+  updateIntermediateStorageEventDayData(event);
 }
 
 export function handlePending(event: Pending): void {
@@ -82,6 +90,8 @@ export function handlePending(event: Pending): void {
 
   entity.save();
   statsEntity.save();
+
+  updatePendingEventDayData(event);
 }
 
 export function handleBulkTransfer(event: BulkTransfer): void {
@@ -112,4 +122,6 @@ export function handleBulkTransfer(event: BulkTransfer): void {
 
   statsEntity.save();
   entity.save();
+
+  updateBulkTransferEventDayData(event);
 }

--- a/hmt_subgraph/src/mapping/EscrowFactory.ts
+++ b/hmt_subgraph/src/mapping/EscrowFactory.ts
@@ -3,6 +3,7 @@ import { Launched } from "../../generated/EscrowFactory/EscrowFactory";
 import { EscrowStatistics, LaunchedEscrow } from "../../generated/schema";
 import { Escrow } from "../../generated/templates";
 import { constructStatsEntity, STATISTICS_ENTITY_ID } from "./Escrow";
+import { updateEscrowAmountDayData } from "./utils/dayUpdates";
 
 export function handleLaunched(event: Launched): void {
   // Entities only exist after they have been saved to the store;
@@ -27,4 +28,6 @@ export function handleLaunched(event: Launched): void {
   // Entities can be written to the store with `.save()`
   entity.save();
   Escrow.create(event.params.escrow);
+
+  updateEscrowAmountDayData(event);
 }

--- a/hmt_subgraph/src/mapping/utils/dayUpdates.ts
+++ b/hmt_subgraph/src/mapping/utils/dayUpdates.ts
@@ -1,0 +1,68 @@
+/* eslint-disable prefer-const */
+import { BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { Launched } from "../../../generated/EscrowFactory/EscrowFactory";
+import { EventDayData } from "../../../generated/schema";
+import {
+  IntermediateStorage,
+  Pending,
+  BulkTransfer,
+} from "../../../generated/templates/Escrow/Escrow";
+
+const ZERO_BI = BigInt.fromI32(0);
+
+function getEventDayData(event: ethereum.Event): EventDayData {
+  let timestamp = event.block.timestamp.toI32();
+  let dayID = timestamp / 86400;
+  let dayStartTimestamp = dayID * 86400;
+
+  let eventDayData = EventDayData.load(dayID.toString());
+  if (eventDayData === null) {
+    eventDayData = new EventDayData(dayID.toString());
+    eventDayData.timestamp = dayStartTimestamp;
+    eventDayData.dailyBulkTransferEvents = ZERO_BI;
+    eventDayData.dailyIntermediateStorageEvents = ZERO_BI;
+    eventDayData.dailyPendingEvents = ZERO_BI;
+    eventDayData.dailyEscrowAmounts = ZERO_BI;
+  }
+  return eventDayData;
+}
+
+export function updateIntermediateStorageEventDayData(
+  event: IntermediateStorage
+): EventDayData {
+  const eventDayData = getEventDayData(event);
+  //@ts-ignore
+  eventDayData.dailyIntermediateStorageEvents += BigInt.fromI32(1);
+  eventDayData.save();
+
+  return eventDayData;
+}
+
+export function updatePendingEventDayData(event: Pending): EventDayData {
+  const eventDayData = getEventDayData(event);
+  //@ts-ignore
+  eventDayData.dailyPendingEvents += BigInt.fromI32(1);
+  eventDayData.save();
+
+  return eventDayData;
+}
+
+export function updateBulkTransferEventDayData(
+  event: BulkTransfer
+): EventDayData {
+  const eventDayData = getEventDayData(event);
+  //@ts-ignore
+  eventDayData.dailyBulkTransferEvents += BigInt.fromI32(1);
+  eventDayData.save();
+
+  return eventDayData;
+}
+
+export function updateEscrowAmountDayData(event: Launched): EventDayData {
+  const eventDayData = getEventDayData(event);
+  //@ts-ignore
+  eventDayData.dailyEscrowAmounts += BigInt.fromI32(1);
+  eventDayData.save();
+
+  return eventDayData;
+}


### PR DESCRIPTION
- Added new entity (EventDayData) to store daily data.
- EventDayData schema will look like this.

> type EventDayData @entity {
>   id: ID!
>   timestamp: Int!
>   dailyBulkTransferEvents: BigInt!
>   dailyIntermediateStorageEvents: BigInt!
>   dailyPendingEvents: BigInt!
>   dailyEscrowAmounts: BigInt!
> }

- We will query `eventDayDatas` from the front-end to show historical dashboard.