### PR TITLE
Replace rinkeby network by goerli

### DIFF
--- a/.github/workflows/graph_deploy.yaml
+++ b/.github/workflows/graph_deploy.yaml
@@ -29,9 +29,9 @@ jobs:
         env:
           API_KEY: ${{ secrets.HP_GRAPH_API_KEY }}
       - run: graph deploy --product hosted-service humanprotocol/polygon
-      - run: node ./scripts/generatenetworkssubgraphs.js rinkeby
+      - run: node ./scripts/generatenetworkssubgraphs.js goerli
       - run: npm run codegen
-      - run: graph deploy --product hosted-service humanprotocol/rinkeby
+      - run: graph deploy --product hosted-service humanprotocol/goerli
       - run: node ./scripts/generatenetworkssubgraphs.js moonbeam
       - run: npm run codegen
       - run: graph deploy --product hosted-service humanprotocol/moonbeam

--- a/hmt_subgraph/README.md
+++ b/hmt_subgraph/README.md
@@ -21,10 +21,10 @@ npm install
 npm run quickstart:matic
 ```
 
-2. Generate & deploy on rinkeby
+2. Generate & deploy on goerli
 
 ```bash
-npm run quickstart:rinkeby
+npm run quickstart:goerli
 ```
 
 You can access it on `http://localhost:8020/`
@@ -55,7 +55,8 @@ npm test
 Following networks are supported : 
 
 - Polygon/matic
-- Rinkeby
+- Goerli
+- Polygon Mumbai (testnet)
 
 ### Add a new network
 
@@ -74,4 +75,6 @@ Currently deploying to:
 
 - main branch -> https://thegraph.com/hosted-service/subgraph/humanprotocol/polygon
 
-- rinkeby branch -> https://thegraph.com/hosted-service/subgraph/humanprotocol/rinkeby
+- goerli branch -> https://thegraph.com/hosted-service/subgraph/humanprotocol/goerli
+
+- mumbai branch -> https://thegraph.com/hosted-service/subgraph/humanprotocol/mumbai

--- a/hmt_subgraph/networks.json
+++ b/hmt_subgraph/networks.json
@@ -27,7 +27,7 @@
     "name": "goerli",
     "description": "Human subgraph on goerli network",
     "EscrowFactory": {
-      "address": "0x925B24444511c86F4d4E63141D8Be0A025E2dca4",
+      "address": "0xaAe6a2646C1F88763E62e0cD08aD050Ea66AC46F",
       "startBlock": 8180730
     },
     "HMToken": {

--- a/hmt_subgraph/networks.json
+++ b/hmt_subgraph/networks.json
@@ -24,8 +24,8 @@
     }
   },
   {
-    "name": "rinkeby",
-    "description": "Human subgraph on rinkeby network",
+    "name": "goerli",
+    "description": "Human subgraph on goerli network",
     "EscrowFactory": {
       "address": "0x925B24444511c86F4d4E63141D8Be0A025E2dca4",
       "startBlock": 8180730

--- a/hmt_subgraph/package.json
+++ b/hmt_subgraph/package.json
@@ -6,7 +6,7 @@
     "compile": "node scripts/compile.js",
     "build": "npm run compile && graph build",
     "quickstart:matic": "npm run compile && node ./scripts/generatenetworkssubgraphs.js matic && graph create --node http://localhost:8020/ posix4e/humansubgraph",
-    "quickstart:rinkeby": "npm run compile && node ./scripts/generatenetworkssubgraphs.js rinkeby && graph create --node http://localhost:8020/ posix4e/humansubgraph",
+    "quickstart:goerli": "npm run compile && node ./scripts/generatenetworkssubgraphs.js goerli && graph create --node http://localhost:8020/ posix4e/humansubgraph",
     "quickstart:mumbai": "npm run compile && node ./scripts/generatenetworkssubgraphs.js mumbai && graph create --node http://localhost:8020/ posix4e/humansubgraph",
     "deploy": "npm run compile && graph deploy --node https://api.thegraph.com/deploy/ posix4e/humansubgraph",
     "test": "graph test",


### PR DESCRIPTION
Due to deprecation in the graph Rinkeby network has to be replaced by Goerli, otherwise DeployGraphs action will fail
![image](https://user-images.githubusercontent.com/61605646/194886445-cd04f287-fc3a-43b7-aa3d-c143447b9779.png)

https://thegraph.com/docs/en/deploying/deploying-a-subgraph-to-hosted/

![image](https://user-images.githubusercontent.com/61605646/194886087-d7b8f611-6cb3-40d7-92e9-28615a9b0308.png)
