### PR TITLE
Fix escrow public bucket URI

### DIFF
--- a/hmt_escrow/storage.py
+++ b/hmt_escrow/storage.py
@@ -39,7 +39,7 @@ ESCROW_RESULTS_AWS_S3_SECRET_ACCESS_KEY = os.getenv(
 ESCROW_AWS_REGION = os.getenv("ESCROW_AWS_REGION", "us-west-2")
 
 ESCROW_ENDPOINT_URL = os.getenv("ESCROW_ENDPOINT_URL", "http://minio:9000")
-ESCROW_PUBLIC_RESULTS_URL = os.getenv("ESCROW_PUBLIC_RESULTS_URL", ESCROW_ENDPOINT_URL)
+ESCROW_PUBLIC_BUCKETNAME = os.getenv("ESCROW_PUBLIC_BUCKETNAME", ESCROW_ENDPOINT_URL)
 
 
 class StorageClientError(Exception):
@@ -96,12 +96,7 @@ def get_public_bucket_url(key: str) -> str:
     Returns:
         str: Bucket public URL
     """
-    base_url = (
-        ESCROW_PUBLIC_RESULTS_URL[:-1]
-        if ESCROW_PUBLIC_RESULTS_URL.endswith("/")
-        else ESCROW_PUBLIC_RESULTS_URL
-    )
-    return f"{base_url}/{key}"
+    return "https://{0}.s3.amazonaws.com/{1}".format(ESCROW_PUBLIC_BUCKETNAME, key)
 
 
 def get_key_from_url(url: str) -> str:
@@ -113,7 +108,7 @@ def get_key_from_url(url: str) -> str:
     Returns:
         str: file key in storage.
     """
-    if url.startswith("http"):
+    if url.startswith("https"):
         # URL is fully qualified URL. Let's split it and try to retrieve key from last part of it.
         key = url.split("/")[-1]
         assert key.startswith("s3")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.4",
+  "version": "0.14.5",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.14.4",
+    version="0.14.5",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",
@@ -17,7 +17,7 @@ setuptools.setup(
     install_requires=[
         "boto3",
         "cryptography",
-        "hmt-basemodels==0.1.18",
+        "hmt-basemodels>=0.1.18",
         "web3==5.24.0",
     ],
 )

--- a/test/hmt_escrow/storage/test_bucket.py
+++ b/test/hmt_escrow/storage/test_bucket.py
@@ -10,8 +10,7 @@ ESCROW_RESULTS_AWS_S3_ACCESS_KEY_ID = "ESCROW_RESULTS_AWS_S3_ACCESS_KEY_ID"
 ESCROW_RESULTS_AWS_S3_SECRET_ACCESS_KEY = "ESCROW_RESULTS_AWS_S3_SECRET_ACCESS_KEY"
 ESCROW_AWS_ACCESS_KEY_ID = "ESCROW_AWS_ACCESS_KEY_ID"
 ESCROW_AWS_SECRET_ACCESS_KEY = "ESCROW_AWS_SECRET_ACCESS_KEY"
-
-ESCROW_TEST_PUBLIC_RESULTS_URL = 'http://my-public-bucket.s3.amazon.com'
+ESCROW_PUBLIC_BUCKETNAME = "my-public-bucket"
 
 
 class BucketTest(unittest.TestCase):
@@ -27,11 +26,11 @@ class BucketTest(unittest.TestCase):
         bucket_name = get_bucket(public=True)
         self.assertEqual(bucket_name, ESCROW_TEST_PUBLIC_BUCKETNAME)
 
-    @patch("hmt_escrow.storage.ESCROW_PUBLIC_RESULTS_URL", ESCROW_TEST_PUBLIC_RESULTS_URL)
+    @patch("hmt_escrow.storage.ESCROW_PUBLIC_BUCKETNAME", ESCROW_PUBLIC_BUCKETNAME)
     def test_public_bucket_url_retrieval(self):
         """ Tests whether bucket public URL is retrieved correctly. """
         key = 's3aaa'
-        expected_url = f'{ESCROW_TEST_PUBLIC_RESULTS_URL}/{key}'
+        expected_url = f"https://{ESCROW_PUBLIC_BUCKETNAME}.s3.amazonaws.com/{key}"
 
         url = get_public_bucket_url(key)
         self.assertEqual(url, expected_url)
@@ -41,7 +40,7 @@ class BucketTest(unittest.TestCase):
         expected_key = 's3aaa'
 
         # Qualified URL must be parsed and key retrieved
-        url = f'{ESCROW_TEST_PUBLIC_RESULTS_URL}/{expected_key}'
+        url = f"https://{ESCROW_PUBLIC_BUCKETNAME}.s3.amazonaws.com/{expected_key}"
         key = get_key_from_url(url)
         self.assertEqual(key, expected_key)
 


### PR DESCRIPTION
The PR fixes generating URI for uploaded escrow results to be public accessible. Currently generated URI seems like `s3://...`, but it should be `https://...`