### PR TITLE
Add CI triggers for job-launcher

### DIFF
--- a/.github/workflows/job-launcher-client-build-and-deploy.yaml
+++ b/.github/workflows/job-launcher-client-build-and-deploy.yaml
@@ -1,14 +1,18 @@
-name: Trigger docker build and deploy dashboard
+name: Trigger docker build and deploy job-launcher-client
 
 on:
   push:
-    branches: [ develop, master ]
+    branches:
+      - develop
+      - master
     paths:
-      - 'escrow-dashboard/**'
+      - 'job-launcher-client/**'
   pull_request:
-    branches: [ develop, master ]
+    branches:
+      - develop
+      - master
     paths:
-      - 'escrow-dashboard/**'
+      - 'job-launcher-client/**'
   workflow_dispatch:
 
 permissions:
@@ -33,7 +37,6 @@ jobs:
             echo "Check out the target branch. A PR to 'master' can only be from the 'develop' branch within the 'humanprotocol' organization."
             exit 1
           fi
-
   trigger-build-and-deploy:
     if: always() && github.repository_owner == 'humanprotocol' && (needs.pull-request-check.result == 'skipped' || needs.pull-request-check.result == 'success')
     needs: pull-request-check
@@ -50,7 +53,7 @@ jobs:
         repo: multi-repo-cicd
         github_token: ${{ secrets.GH_TOKEN }}
         workflow_file_name: docker_build_and_deploy.yml
-        ref: escrow-dashboard
+        ref: job-launcher-client
         wait_interval: 15
         client_payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}", "trigger": "${{  github.event_name }}"}'
         propagate_failure: true

--- a/.github/workflows/job-launcher-server-build-and-deploy.yaml
+++ b/.github/workflows/job-launcher-server-build-and-deploy.yaml
@@ -1,14 +1,14 @@
-name: Trigger docker build and deploy dashboard
+name: Trigger docker build and deploy job-launcher-server
 
 on:
   push:
     branches: [ develop, master ]
     paths:
-      - 'escrow-dashboard/**'
+      - 'job-launcher-server/**'
   pull_request:
     branches: [ develop, master ]
     paths:
-      - 'escrow-dashboard/**'
+      - 'job-launcher-server/**'
   workflow_dispatch:
 
 permissions:
@@ -33,7 +33,6 @@ jobs:
             echo "Check out the target branch. A PR to 'master' can only be from the 'develop' branch within the 'humanprotocol' organization."
             exit 1
           fi
-
   trigger-build-and-deploy:
     if: always() && github.repository_owner == 'humanprotocol' && (needs.pull-request-check.result == 'skipped' || needs.pull-request-check.result == 'success')
     needs: pull-request-check
@@ -50,7 +49,7 @@ jobs:
         repo: multi-repo-cicd
         github_token: ${{ secrets.GH_TOKEN }}
         workflow_file_name: docker_build_and_deploy.yml
-        ref: escrow-dashboard
+        ref: job-launcher-server
         wait_interval: 15
         client_payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repository": "${{ github.repository }}", "trigger": "${{  github.event_name }}"}'
         propagate_failure: true


### PR DESCRIPTION
Added GitHub Actions that triggers a CI process in the [job-launcher-client](https://github.com/humanprotocol/multi-repo-cicd/tree/job-launcher-client) and [job-launcher-server](https://github.com/humanprotocol/multi-repo-cicd/tree/job-launcher-server). Also added paths, changes in which trigger actions.

Closed PR's in archival repositories:
https://github.com/humanprotocol/job-launcher-server/pull/6
https://github.com/humanprotocol/job-launcher-client/pull/20