### PR TITLE
Add support download files drom public URI

### DIFF
--- a/hmt_escrow/storage.py
+++ b/hmt_escrow/storage.py
@@ -2,6 +2,8 @@ import hashlib
 import json
 import logging
 import os
+import urllib.request
+import re
 from typing import Dict, Tuple, Optional, Union
 
 import boto3
@@ -163,7 +165,13 @@ def download(key: str, private_key: bytes, public: bool = False) -> Dict:
 
     """
     try:
-        content = download_from_storage(key=key, public=public)
+        url_pattern = "^https?:\\/\\/(?:www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$"
+        is_url = re.match(url_pattern, key)
+        content = (
+            urllib.request.urlopen(key).read()
+            if is_url
+            else download_from_storage(key=key, public=public)
+        )
         artifact = (
             crypto.decrypt(private_key, content)
             if crypto.is_encrypted(content) is True

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.14.5",
+    version="0.14.6",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",

--- a/test/hmt_escrow/storage/test_storage.py
+++ b/test/hmt_escrow/storage/test_storage.py
@@ -209,6 +209,22 @@ class StorageTest(unittest.TestCase):
             # Download from storage must be called as PRIVATE (public is TRUE)
             download_mock.assert_called_once_with(key=file_key, public=True)
 
+    def test_download_from_public_resource(self):
+        file_key = "https://s3aaa.com"
+        sample_data = '{"a": 1, "b": 2}'
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            cm = MagicMock()
+            cm.read.side_effect = [
+                crypto.encrypt(self.pub_key, sample_data),
+                sample_data.encode("utf-8"),
+            ]
+            mock_urlopen.return_value = cm
+
+            downloaded = download(key=file_key, private_key=self.priv_key)
+            self.assertEqual(json.dumps(downloaded), sample_data)
+            mock_urlopen.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main(exit=True)


### PR DESCRIPTION
In order to support run jobs that was deployed by anyone need to change code that downloads encrypted manifest from public URI.

Changes was applied for `def download`: if `key` contains http/https just upload resource using get request