### PR TITLE
Read bulk_payout logs to avoid double payouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hmt-escrow",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "Launch escrow contracts to the HUMAN network",
   "main": "truffle.js",
   "directories": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-escrow",
-    version="0.14.6",
+    version="0.14.7",
     author="HUMAN Protocol",
     description="A python library to launch escrow contracts to the HUMAN network.",
     url="https://github.com/humanprotocol/hmt-escrow",


### PR DESCRIPTION
To avoid double payouts `bulk_payout` method has been reworked: read `bulk_payout` transaction receipt and check events of transaction to catch `Transfer` event and make sure that payout has been processed.